### PR TITLE
task-05: update helper description for NIB

### DIFF
--- a/05-single-hop-route/05-single-hop-route.md
+++ b/05-single-hop-route/05-single-hop-route.md
@@ -6,7 +6,9 @@ Task #01
 
 ICMPv6 echo request/reply exchange between two native nodes with global unicast
 addresses. A static default route has to be used
-(`nib route add <iface> :: <dst link-local>`).
+(`nib route add <iface> :: <dst link-local>`, also remember to deactivate router
+advertisements on both ends *beforehand* with `ifconfig <iface> -rtr_adv`,
+otherwise default routes and address resolution will be auto-configured).
 * Stack configuration: IPv6 (default)
 * Count:                  100
 * Interval:               10ms
@@ -25,7 +27,8 @@ Task #02
 ICMPv6 echo request/reply exchange between two iotlab-m3 nodes with global
 unicast addresses. The sending node uses global unicast address with a
 different prefix. A static default route has to be used
-(`nib route add <iface> :: <dst link-local>`).
+(`nib route add <iface> :: <dst link-local>`, *do not* deactivate router
+advertisements for this task).
 * Stack configuration: IPv6 (default)
 * Count:                  100
 * Interval:               10ms
@@ -43,7 +46,9 @@ Task #03
 
 ICMPv6 echo request/reply exchange between two native nodes with global unicast
 addresses. A static /64 route has to be used
-(`nib route add <iface> :: <dst link-local>`).
+(`nib route add <iface> beef::/64 <dst link-local>`, also remember to deactivate
+router advertisements on both ends *beforehand* with `ifconfig <iface> -rtr_adv`,
+otherwise default routes and address resolution will be auto-configured ).
 * Stack configuration: IPv6 (default)
 * Count:                  10
 * Interval:               10ms

--- a/05-single-hop-route/05-single-hop-route.md
+++ b/05-single-hop-route/05-single-hop-route.md
@@ -5,7 +5,8 @@ Task #01
 ### Description
 
 ICMPv6 echo request/reply exchange between two native nodes with global unicast
-addresses. A static default route has to be used (`fibroute add :: via <dst link-local>`).
+addresses. A static default route has to be used
+(`nib route add <iface> :: <dst link-local>`).
 * Stack configuration: IPv6 (default)
 * Count:                  100
 * Interval:               10ms
@@ -23,7 +24,8 @@ Task #02
 
 ICMPv6 echo request/reply exchange between two iotlab-m3 nodes with global
 unicast addresses. The sending node uses global unicast address with a
-different prefix. A static default route has to be used (`fibroute add :: via <dst link-local>`).
+different prefix. A static default route has to be used
+(`nib route add <iface> :: <dst link-local>`).
 * Stack configuration: IPv6 (default)
 * Count:                  100
 * Interval:               10ms
@@ -40,7 +42,8 @@ Task #03
 ### Description
 
 ICMPv6 echo request/reply exchange between two native nodes with global unicast
-addresses. A static /64 route has to be used (`fibroute add beef::/64 via <dst link-local>`).
+addresses. A static /64 route has to be used
+(`nib route add <iface> :: <dst link-local>`).
 * Stack configuration: IPv6 (default)
 * Count:                  10
 * Interval:               10ms


### PR DESCRIPTION
Replaces `fibroute` command in task 5 with `nib route` command.