### PR TITLE
6Lo tests: also check for pktbuf leaks

### DIFF
--- a/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
+++ b/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
@@ -47,6 +47,7 @@ ICMPv6 echo request/reply exchange between two nodes.
 ### Result
 
 <10% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #04
 ========

--- a/05-single-hop-route/05-single-hop-route.md
+++ b/05-single-hop-route/05-single-hop-route.md
@@ -19,6 +19,7 @@ otherwise default routes and address resolution will be auto-configured).
 ### Result
 
 <1% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 
 Task #02
@@ -40,6 +41,7 @@ advertisements for this task).
 ### Result
 
 <10% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #03
 ========
@@ -60,6 +62,7 @@ otherwise default routes and address resolution will be auto-configured ).
 ### Result
 
 <1% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #04
 ========

--- a/06-single-hop-udp/06-single-hop-udp.md
+++ b/06-single-hop-udp/06-single-hop-udp.md
@@ -16,6 +16,7 @@ Sending UDP between two iotlab-m3 nodes.
 ### Result
 
 <5% packets lost on the receiving node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #02
 ========
@@ -33,3 +34,4 @@ Sending UDP between two iotlab-m3 nodes.
 ### Result
 
 <5% packets lost on the receiving node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).

--- a/07-multi-hop/07-multi-hop.md
+++ b/07-multi-hop/07-multi-hop.md
@@ -10,6 +10,7 @@ with static routes.
 ### Result
 
 <20% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #02
 ========
@@ -20,6 +21,7 @@ Sending UDP between two iotlab-m3 nodes over three hops with static routes.
 ### Result
 
 <10% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #03
 ========
@@ -31,6 +33,7 @@ with RPL generated routes.
 ### Result
 
 <20% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
 Task #04
 ========
@@ -41,3 +44,4 @@ Sending UDP between two iotlab-m3 nodes over three hops with RPL generated route
 ### Result
 
 <10% packets lost on the pinging node.
+No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).


### PR DESCRIPTION
I found some leaks in the packet buffer for certain conditions in
fragmentation. While not fixed in master at the writing of this change
in RIOT's master, this serves as a reminder that that should be
checked.