### PR TITLE
07-multi-hop: Fix issues found when doing Release 2018.04

### DIFF
--- a/07-multi-hop/IOTLABHelper.py
+++ b/07-multi-hop/IOTLABHelper.py
@@ -26,7 +26,7 @@ class IOTLABHelper:
         self.testbed = None
 
     def __getLivingNodesFromTestbed(self, site, nodeType):
-        nodesStr = check_output(shlex.split("experiment-cli info -li"), universal_newlines=True)
+        nodesStr = check_output(shlex.split("iotlab-experiment info -li"), universal_newlines=True)
         nodesJSON = json.loads(nodesStr)['items']
         for siteJSON in nodesJSON:
             if site not in siteJSON:
@@ -36,7 +36,7 @@ class IOTLABHelper:
 
     def __getPhysicalLocation(self, nodes, site, nodeType):
         nodesWithPos = list()
-        nodesStr = check_output(shlex.split("experiment-cli info -l --site {0}".format(site)), \
+        nodesStr = check_output(shlex.split("iotlab-experiment info -l --site {0}".format(site)), \
                                 universal_newlines=True)
         nodesJSON = json.loads(nodesStr)['items']
         for node in nodesJSON:

--- a/07-multi-hop/IOTLABHelper.py
+++ b/07-multi-hop/IOTLABHelper.py
@@ -81,7 +81,7 @@ class IOTLABHelper:
         iotlabrc = os.path.expanduser('~') + os.path.sep + ".iotlabrc"
         user = check_output(shlex.split("cut -f1 -d: " + iotlabrc), universal_newlines=True).rstrip()
         print("Authenticated as user: {0}".format(user))
-        
+
         if nodes:
             nodes = self.__extractNodes(nodes)
             nodes = self.__getPhysicalLocation(nodes, site, nodesType)
@@ -93,7 +93,7 @@ class IOTLABHelper:
 
         nodesStr = self.__compressNodes(self.randomNodes)
         print("Starting experiment with nodes: {0}".format(nodesStr))
-        
+
         exp_cmd = "make iotlab-exp -I ../../dist/testbed-support IOTLAB_USER={0} IOTLAB_EXP_NAME={1} " \
                   "IOTLAB_DURATION={2} BOARD=iotlab-m3 IOTLAB_PHY_NODES={3}" \
                   .format(user, expName, expDur, nodesStr)
@@ -106,7 +106,7 @@ class IOTLABHelper:
             print("Experiment id could not be parsed")
             return None
         print("Experiment with id {0} started".format(expId))
-        
+
         self.testbed = self.startAggregator(user, site, expId)
         print("Aggregator started")
 
@@ -146,7 +146,7 @@ class IOTLABHelper:
         if self.testbed.expect([pexpect.TIMEOUT, "inet6 addr: {0}/".format(ip)], timeout=1) != 0:
             return True
         return False
-     
+
     def configureIPAddresses(self, ipFormat, nodeType, nodes):
         ret = True
         for node in nodes:

--- a/07-multi-hop/IOTLABHelper.py
+++ b/07-multi-hop/IOTLABHelper.py
@@ -137,13 +137,13 @@ class IOTLABHelper:
 
     def findAddressByPrefix(self, nodeType, nodeId, iface, prefix):
         self.testbed.sendline("{0}-{1};ifconfig {2}".format(nodeType, nodeId, iface))
-        if self.testbed.expect([pexpect.TIMEOUT, "inet6 addr: ({0}[:0-9a-f]+)/".format(prefix)], timeout=1) != 0:
+        if self.testbed.expect([pexpect.TIMEOUT, "inet6 addr: ({0}[:0-9a-f]+) ".format(prefix)], timeout=1) != 0:
             return self.testbed.match.group(1)
         return None
 
     def hasAddress(self, nodeType, nodeId, iface, ip):
         self.testbed.sendline("{0}-{1};ifconfig {2}".format(nodeType, nodeId, iface))
-        if self.testbed.expect([pexpect.TIMEOUT, "inet6 addr: {0}/".format(ip)], timeout=1) != 0:
+        if self.testbed.expect([pexpect.TIMEOUT, "inet6 addr: {0} ".format(ip)], timeout=1) != 0:
             return True
         return False
 

--- a/07-multi-hop/task01.py
+++ b/07-multi-hop/task01.py
@@ -26,7 +26,7 @@ def testPing(helper, nodes, hops):
 
     for win in helper.window(sortedNodes, hops):
         print("window: {0}".format([v[0] for v in win]))
-        helper.setFibRoutesInARow(win, IOTLAB_ARCH, IFACE, globalIPFormat)
+        helper.setNibRoutesInARow(win, IOTLAB_ARCH, IFACE, globalIPFormat)
         if helper.ping(globalIPFormat.format(format(win[-1][0], 'x')), IOTLAB_ARCH, win[0],
                 PINGCOUNT, PINGPAYLOADSZ, PINGDELAY):
             return True

--- a/07-multi-hop/task01.py
+++ b/07-multi-hop/task01.py
@@ -63,9 +63,9 @@ while len(availableNodes):
     node = availableNodes[0]
     sortedNodes.append(node)
     availableNodes.remove(availableNodes[0])
-    sorted(availableNodes, key=lambda x: math.sqrt(math.pow(x[1]-node[1],2) + \
-                                          math.pow(x[2]-node[2],2) + \
-                                          math.pow(x[3]-node[3],2)))
+    availableNodes.sort(key=lambda x: (math.pow(x[1]-node[1],2) +
+                                       math.pow(x[2]-node[2],2) +
+                                       math.pow(x[3]-node[3],2)))
 
 print("order of nodes for ping test: {0}".format([v[0] for v in sortedNodes]))
 

--- a/07-multi-hop/task02.py
+++ b/07-multi-hop/task02.py
@@ -70,9 +70,9 @@ while len(availableNodes):
     node = availableNodes[0]
     sortedNodes.append(node)
     availableNodes.remove(availableNodes[0])
-    sorted(availableNodes, key=lambda x: math.sqrt(math.pow(x[1]-node[1],2) + \
-                                          math.pow(x[2]-node[2],2) + \
-                                          math.pow(x[3]-node[3],2)))
+    availableNodes.sort(key=lambda x: (math.pow(x[1]-node[1],2) +
+                                       math.pow(x[2]-node[2],2) +
+                                       math.pow(x[3]-node[3],2)))
 
 print("order of nodes for udp test: {0}".format([v[0] for v in sortedNodes]))
 

--- a/07-multi-hop/task02.py
+++ b/07-multi-hop/task02.py
@@ -26,7 +26,7 @@ def testUDP(helper, nodes, hops):
 
     for win in helper.window(sortedNodes, hops):
         print("window: {0}".format([v[0] for v in win]))
-        helper.setFibRoutesInARow(win, IOTLAB_ARCH, IFACE, globalIPFormat)
+        helper.setNibRoutesInARow(win, IOTLAB_ARCH, IFACE, globalIPFormat)
         p = 0.0
         for i in range(20):
             if not helper.sendUDP(globalIPFormat.format(format(win[0][0], 'x')), \


### PR DESCRIPTION
This fixes issues I got when running 07-multi-hop for the last release

My main concern is that `ifconfig` does not print the `/PREFIX` on addresses and I do not know if it is really a wanted thing or not. However it is required for running the tests.

* Update to `nib` shell commands
* Fix nodes not being sorted as `sorted` does not sort in place
* Update to the new `ifconfig` API

And some cleanups

* Update to an unicode pexpect (I think I got decode error but not sure anymore)
* Update to new iotlab- commands to not get deprecation warnings
* Whitespace

Referenced in:

https://github.com/RIOT-OS/Release-Specs/issues/62#issuecomment-388376218