### PR TITLE
01-ci: update scripts

### DIFF
--- a/01-ci/task01.py
+++ b/01-ci/task01.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import pexpect
 import os
 import sys
-import time
+import pexpect
 
 if len(sys.argv) < 2:
     print("Usage: %s <RIOT directory>" % (sys.argv[0]))
@@ -12,7 +11,8 @@ else:
     os.chdir(sys.argv[1])
 
 print("Run task #01")
-child = pexpect.spawn("./dist/tools/compile_test/compile_test.py", timeout=3600)
+child = pexpect.spawnu("./dist/tools/compile_test/compile_test.py",
+                       timeout=None, logfile=sys.stdout)
 try:
     child.expect("failed")
     print("!!! compile tests failed")

--- a/01-ci/task01.py
+++ b/01-ci/task01.py
@@ -1,21 +1,71 @@
 #!/usr/bin/env python3
 
+"""Compile all tests and examples for all boards.
+
+Usage
+-----
+
+```
+usage: task01.py [-h] [--stop] riot_directory
+
+compile all tests and examples for all boards
+
+positional arguments:
+  riot_directory
+
+optional arguments:
+  -h, --help      show this help message and exit
+  --stop          Stop test on first error
+```
+"""
+
 import os
 import sys
+import argparse
+
 import pexpect
 
-if len(sys.argv) < 2:
-    print("Usage: %s <RIOT directory>" % (sys.argv[0]))
-    sys.exit(1)
-else:
-    os.chdir(sys.argv[1])
 
-print("Run task #01")
-child = pexpect.spawnu("./dist/tools/compile_test/compile_test.py",
-                       timeout=None, logfile=sys.stdout)
-try:
-    child.expect("failed")
-    print("!!! compile tests failed")
-    sys.exit(1)
-except pexpect.EOF:
+PARSER = argparse.ArgumentParser(
+    description='Compile all tests and examples for all boards')
+PARSER.add_argument('riot_directory')
+PARSER.add_argument('--stop', action='store_true', default=False,
+                    help='Stop test on first error')
+
+
+def _run_compile_tests(riot_directory, stop=False):
+    """Run compile tests and return the number of "failed"."""
+    os.chdir(riot_directory)
+
+    child = pexpect.spawnu("./dist/tools/compile_test/compile_test.py",
+                           timeout=None, logfile=sys.stdout)
+    errors = 0
+    try:
+        while True:
+            child.expect("failed")
+            errors += 1
+            if stop:
+                break
+    except pexpect.EOF:
+        pass
+
+    return errors
+
+
+def main():
+    """Execute compilation tests."""
+    args = PARSER.parse_args()
+
+    print("Run task #01")
+
+    errors = _run_compile_tests(args.riot_directory, args.stop)
+
+    if errors:
+        print("!!! %u compile tests failed" % errors)
+        exit(errors)
+
     print("SUCCESS")
+
+
+if __name__ == '__main__':
+    main()

--- a/01-ci/task02.py
+++ b/01-ci/task02.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import pexpect
 import os
 import sys
-import time
+import subprocess
 
 TESTBOARD = "native"
 
@@ -17,10 +16,9 @@ os.chdir("tests/unittests")
 os.environ['BOARD'] = TESTBOARD
 
 print("Run task #02")
-child = pexpect.spawn("make -B clean all term")
 try:
-    child.expect("OK ")
-except pexpect.EOF:
+    subprocess.check_call(["make", "-B", "clean", "all", "test"])
+except subprocess.CalledProcessError:
     print("!!! Unittests failed")
     sys.exit(1)
 

--- a/01-ci/task03.py
+++ b/01-ci/task03.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import pexpect
 import os
 import sys
-import time
+import subprocess
 
 TESTBOARD = "native"
 
@@ -20,10 +19,9 @@ print("Run task #03")
 tests = os.listdir(".")
 for t in tests:
     if t.startswith("tests-"):
-        child = pexpect.spawn("make -B clean %s term" % t)
         try:
-            child.expect("OK ")
-        except pexpect.EOF:
+            subprocess.check_call(["make", "-B", "clean", t, "test"])
+        except subprocess.CalledProcessError:
             print("!!! Unittest %s failed" % t)
             sys.exit(1)
 

--- a/01-ci/task04.py
+++ b/01-ci/task04.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import pexpect
 import os
 import sys
-import time
+import subprocess
 
 TESTBOARD = "iotlab-m3"
 
@@ -15,23 +14,20 @@ else:
 
 os.chdir("tests/unittests")
 
-os.environ['BOARD'] = TESTBOARD 
+os.environ['BOARD'] = TESTBOARD
+
 print("Run task #04")
-pexpect.run("make -B clean all")
-child = pexpect.spawn("make flash")
+subprocess.check_call(['make', '-B', 'clean', 'all'])
 
 try:
-    child.expect("verified")
-except pexpect.EOF:
+    subprocess.check_call(['make', 'flash-only'])
+except subprocess.CalledProcessError:
     print("!!! Flashing %s failed" % TESTBOARD)
     sys.exit(1)
 
-child = pexpect.spawn("make term")
-time.sleep(1)
-pexpect.run("make reset")
 try:
-    child.expect("OK ")
-except pexpect.EOF:
+    subprocess.check_call(['make', 'test'])
+except subprocess.CalledProcessError:
     print("!!! Unittests on %s failed" % TESTBOARD)
     sys.exit(1)
 


### PR DESCRIPTION
Changes are:

* Use python3
* Print execution output
* Remove execution timeout, (I replaced by `subprocess` for some executions).
* use `make test` when possible
* Use `spawnu` for unicode

I had trouble running the tests for 01-ci due to the timeouts.
I took some time to update the scripts to python3 and using make test.