### PR TITLE
09-coap: add CoAP release specs

### DIFF
--- a/09-coap/coap.md
+++ b/09-coap/coap.md
@@ -1,0 +1,212 @@
+## Goal: Send/Receive typical CoAP messages
+
+Introduction
+============
+With all of these tests, your confidence in the results will increase by
+watching the CoAP messages in Wireshark.
+
+These tests all were developed using native on a recent Ubuntu Linux. However,
+they all may be run just as well on hardware.
+
+Materials
+---------
+
+You'll need a recent copy of [aiocoap](https://github.com/chrysn/aiocoap).
+
+Setup
+-----
+
+Some of these examples use a tap interface with a ULA configured on a Unix-like
+system as:
+```
+    $ ip address add fd00:bbbb::1/64 dev tap0 scope global
+```
+
+Use the included `setup_tap.sh` to automate creation of this interface and
+address, and `teardown_tap.sh` to remove it.
+
+The ULA must be configured manually in the RIOT SUT at the command line with:
+```
+    > ifconfig 6 add unicast fd00:bbbb::2/64
+```
+
+Notice that the address for the SUT uses host '2', and the other endpoint uses
+host '1'.
+
+
+Task #01 - CORD Endpoint
+========================
+### Description
+
+Client registers with an aiocoap CORE Resource Directory (RD) server. Exercises
+confirmable (CON) client and server messaging with gcoap.
+
+### Result
+
+Registration succeeds, and client refreshes registration periodically.
+
+### Details
+
+On a Linux machine, start an aiocoap example server with the `aiocoap-rd`
+script.
+
+Start a native terminal for the RIOT cord_ep example app.
+
+Register with the RD server with the command:
+```
+   > cord_ep register [fd00:bbbb::1]
+```
+
+You should see the message below in the RIOT native terminal:
+```
+registration successful
+
+CoAP RD connection status:
+RD address: coap://[fd00:bbbb::1]:5683
+   ep name: RIOT-2D0C232323232323
+  lifetime: 60s
+    reg if: /resourcedirectory
+  location: /reg/1/
+
+```
+
+Periodically, the client re-registers with the server. You should see the
+message below in the RIOT terminal:
+```
+RD endpoint event: successfully updated client registration
+```
+
+
+Task #02 - Confirmable retries
+==============================
+### Description
+
+gcoap sends a CON GET request to an aiocoap server. The test runner delays
+startup of aiocoap to trigger gcoap to resend the message.
+
+### Result
+gcoap receives the server response and stops resending messages. If the server
+is not started within the timeout window, gcoap gives up and reports the timeout.
+
+### Details
+gcoap attempts a maximum of four retries; five messages altogether including
+the initial one. The retries are timed with CoAP's exponential backoff mechanism
+and jitter. The retry interval doubles with each attempt and varies +/- 50% of
+the interval. So, the sequence is:
+
+* original, wait  2 +- 1
+* retry 1,  wait  4 +- 2
+* retry 2,  wait  8 +- 4
+* retry 3,  wait 16 +- 8
+* retry 4,  wait 32 +-16
+* timeout
+
+Start the gcoap example and send a CON message to aiocoap:
+```
+    > coap get -c fd00:bbbb::1 5683 /time
+```
+
+Wait some period of time, and then start the aiocoap example server
+```
+    $ server.py
+```
+
+On the next retry gcoap shows it received the response:
+```
+gcoap: response Success, code 2.05, 16 bytes
+```
+
+or, if gcoap has timed out:
+```
+gcoap: timeout for msg ID 50754
+```
+
+
+Task #03 - Block1
+=================
+### Description
+
+aiocoap slices a payload into a sequence of Block1 encoded POSTs to nanocoap.
+nanocoap computes and returns the SHA-256 message digest of the payload.
+
+### Result
+
+nanocoap returns the expected message digest in a 2.04 response.
+
+### Details
+
+Start the nanocoap_server example. Then run `task03.py` as described in the
+comment at the top of that file.
+
+
+Task #04 - Block2
+=================
+### Description
+
+aiocoap GETs a sequence of Block2 encoded packets from nanocoap that encode
+information about a RIOT instance.
+
+### Result
+
+nanocoap returns the expected payload in a 2.05 response.
+
+### Details
+
+Start the nanocoap_server example. Then run `task04.py` as described in the
+comment at the top of that file.
+
+
+Task #05 - Observe registration and notification
+================================================
+### Description
+
+aiocoap sends an Observe request to gcoap. gcoap then sends a request itself,
+which updates its observed resource. This update triggers gcoap to send an
+Observe notification to aiocoap.
+
+### Result
+
+* aiocoap receives an initial response with an Observe option
+* gcoap receives a request from aiocoap for /time
+* aiocoap receives a following observe notification
+
+### Details
+
+Start the gcoap example server. If desired, configure the ULA as described in
+the Introduction section
+
+    > ifconfig 6 add unicast fd00:bbbb::2/64
+
+Start the aiocoap server in `task05.py`, as described at the top of that file.
+aiocoap automatically sends a get request to gcoap to register for the
+/cli/stats resource.
+
+aiocoap receives the initial response, which show 0 for the resource value:
+```
+First response: <aiocoap.Message at 0x7f84dfa11c18: Type.ACK 2.05 Content
+(MID 21466, token 6f1d) remote <UDP6EndpointAddress [fd00:bbbb::2]:5683 with
+local address>, 2 option(s), 1 byte(s) payload>
+b'0'
+```
+
+Then paste the command below into the gcoap command line:
+```
+    > coap get -c fd00:bbbb::1 5683 /time
+```
+
+gcoap prints the response below from aiocoap:
+```
+gcoap: response Success, code 2.05, 16 bytes
+2018-10-30 08:19
+
+```
+
+aiocoap prints the response below from the Observe notification:
+```
+Next result: <aiocoap.Message at 0x7f84dfa15240: Type.NON 2.05 Content
+(MID 17807, token 6f1d) remote <UDP6EndpointAddress [fd00:bbbb::2]:5683 with
+local address>, 2 option(s), 1 byte(s) payload>
+b'1'
+Loop ended, wait 10 sec
+
+```

--- a/09-coap/setup_tap.sh
+++ b/09-coap/setup_tap.sh
@@ -1,0 +1,17 @@
+# Set up tap networking for tests.
+
+sudo ip tuntap add tap0 mode tap user ${USER}
+
+# Set HW address to similar format to the IP address we want for testing.
+sudo ip link set dev tap0 address 0:0:bb:bb:0:1
+
+# Create hardware-based link-local IP address
+sudo ip address add fe80::200:bbff:febb:1/64 dev tap0 scope link
+
+# Add unique local address so we don't rely on a link-local address.
+sudo ip address add fd00:bbbb::1/64 dev tap0 scope global
+
+sudo ip link set tap0 up
+
+ifconfig
+

--- a/09-coap/task03.py
+++ b/09-coap/task03.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+"""
+Test nanocoap Block1 server response to SHA256 hash request payload
+
+Expected result: aiocoap prints response code 2.04 and SHA256 digest
+
+Usage:
+    usage: task03.py [-h] -r HOST [-b BLOCK_SIZE]
+
+    optional arguments:
+      -h, --help     show this help message and exit
+      -r HOST        remote host for URI
+      -b BLOCK_SIZE  one of 16, 32, 64, ..., 1024
+
+Example:
+
+$ PYTHONPATH="/home/kbee/src/aiocoap" ./task03.py -r [fe80::200:bbff:febb:2%tap0]
+
+WARNING:coap.blockwise-requester:Block1 option completely ignored by server,
+assuming it knows what it is doing.
+Result: 2.04 Changed
+b'BEF6D998FB07110712EC8DC5AF83EE399EAC875F7FE44423348A0E0D8254C8AA'
+"""
+
+import logging
+import asyncio
+import math
+from argparse import ArgumentParser
+from aiocoap import *
+
+logging.basicConfig(level=logging.INFO)
+
+async def main(host, block_size):
+    # create async context and wait a couple of seconds
+    context = await Context.create_client_context()
+    await asyncio.sleep(2)
+
+    payload = (b'If one advances confidently in the direction of his dreams,'
+               b' he will meet with a success unexpected in common hours.')
+
+    request = Message(code=POST, payload=payload,
+                      uri='coap://{0}/sha256'.format(host))
+
+    block_exp = round(math.log(block_size, 2)) - 4
+    request.opt.block1 = optiontypes.BlockOption.BlockwiseTuple(0, 0, block_exp)
+
+    response = await context.request(request).response
+
+    print('Result: %s\n%r'%(response.code, response.payload))
+
+if __name__ == "__main__":
+    # read command line
+    parser = ArgumentParser()
+    parser.add_argument('-r', dest='host', required=True,
+                        help='remote host for URI')
+    parser.add_argument('-b', dest='block_size', type=int, default=32,
+                        help='one of 16, 32, 64, ..., 1024')
+
+    args = parser.parse_args()
+
+    asyncio.get_event_loop().run_until_complete(main(args.host, args.block_size))

--- a/09-coap/task04.py
+++ b/09-coap/task04.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+"""
+Test nanocoap Block2 server response to GET request
+
+Expected result: aiocoap prints response code 2.05 and payload
+
+Usage:
+    usage: task04.py [-h] -r HOST [-b BLOCK_SIZE]
+
+    optional arguments:
+      -h, --help     show this help message and exit
+      -r HOST        remote host for URI
+      -b BLOCK_SIZE  one of 16, 32, 64, ..., 1024
+
+Example:
+
+$ PYTHONPATH="/home/kbee/src/aiocoap" ./task04.py -r [fe80::200:bbff:febb:2%tap0]
+
+Result: 2.05 Content
+b'This is RIOT (Version: 2018.04-devel-3264-g99ae4-gazelle-2018.10-branch)
+running on a native board with a native MCU.'
+"""
+
+import logging
+import asyncio
+import math
+from argparse import ArgumentParser
+from aiocoap import *
+
+logging.basicConfig(level=logging.INFO)
+
+async def main(host, block_size):
+    # create async context and wait a couple of seconds
+    context = await Context.create_client_context()
+    await asyncio.sleep(2)
+
+    request = Message(code=GET, uri='coap://{0}/riot/ver'.format(host))
+
+    block_exp = round(math.log(block_size, 2)) - 4
+    request.opt.block2 = optiontypes.BlockOption.BlockwiseTuple(0, 0, block_exp)
+
+    response = await context.request(request).response
+
+    print('Result: %s\n%r'%(response.code, response.payload))
+
+if __name__ == "__main__":
+    # read command line
+    parser = ArgumentParser()
+    parser.add_argument('-r', dest='host', required=True,
+                        help='remote host for URI')
+    parser.add_argument('-b', dest='block_size', type=int, default=32,
+                        help='one of 16, 32, 64, ..., 1024')
+
+    args = parser.parse_args()
+
+    asyncio.get_event_loop().run_until_complete(main(args.host, args.block_size))

--- a/09-coap/task05.py
+++ b/09-coap/task05.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+"""
+Test gcoap Observe implementation
+
+Acts as client and observer for gcoap Observe server for /cli/stats resource.
+Also acts as server for /time resource. gcoap requests time from aiocoap, which
+updates gcoap's /cli/stats resource. This update triggers gcoap to send a
+notification to aiocoap.
+
+Expected result: aiocoap prints response code 2.05 and payload for initial
+response to Observe request, and for following notification.
+
+Usage:
+    usage: task05.py [-h] -r HOST
+
+    optional arguments:
+      -h, --help  show this help message and exit
+      -r HOST     remote host for URI
+
+Example:
+
+$ PYTHONPATH="/home/kbee/src/aiocoap" ./task05.py -r [fd00:bbbb::2]
+
+First response: <aiocoap.Message at 0x7f84dfa11c18: Type.ACK 2.05 Content
+(MID 21466, token 6f1d) remote <UDP6EndpointAddress [fd00:bbbb::2]:5683 with
+local address>, 2 option(s), 1 byte(s) payload>
+b'0'
+
+[gcoap requests /time]
+
+Next result: <aiocoap.Message at 0x7f84dfa15240: Type.NON 2.05 Content
+(MID 17807, token 6f1d) remote <UDP6EndpointAddress [fd00:bbbb::2]:5683 with
+local address>, 2 option(s), 1 byte(s) payload>
+b'1'
+
+Loop ended, wait 10 sec
+"""
+
+import logging
+import asyncio
+import datetime
+from argparse import ArgumentParser
+
+import aiocoap.resource as resource
+from aiocoap import *
+
+logging.basicConfig(level=logging.INFO)
+
+class TimeResource(resource.Resource):
+    """Handle GET for clock time."""
+
+    async def render_get(self, request):
+        payload = datetime.datetime.now().\
+                strftime("%Y-%m-%d %H:%M").encode('ascii')
+        msg = Message(payload=payload)
+        msg.opt.content_format = 0
+        return msg
+
+async def main(host):
+    # setup server resources
+    root = resource.Site()
+    root.add_resource(('time',), TimeResource())
+
+    context = await Context.create_server_context(root)
+
+    msg = Message(code=GET, uri='coap://{0}/cli/stats'.format(host), observe=0)
+    req = context.request(msg)
+
+    resp = await req.response
+    print("First response: %s\n%r"%(resp, resp.payload))
+
+    async for resp in req.observation:
+        print("Next result: %s\n%r"%(resp, resp.payload))
+
+        req.observation.cancel()
+        break
+
+    print("Loop ended, wait 10 sec")
+    await asyncio.sleep(10)
+
+if __name__ == "__main__":
+    # read command line
+    parser = ArgumentParser()
+    parser.add_argument('-r', dest='host', required=True,
+                        help='remote host for URI')
+
+    args = parser.parse_args()
+
+    asyncio.get_event_loop().run_until_complete(main(args.host))

--- a/09-coap/teardown_tap.sh
+++ b/09-coap/teardown_tap.sh
@@ -1,0 +1,4 @@
+# Tears down tap interface created with setup_tap.sh
+
+sudo ip link set tap0 down
+sudo ip link delete tap0


### PR DESCRIPTION
### Contribution description
Basic coverage for CoAP messaging as described in #73. The goal for this PR is to include non-confirmable and confirmable messaging, block extension, and observe extension. Includes some tests for both gcoap and nanocoap. Includes test of RIOT Resource Directory client implementation (CORD).

Initial commit probably premature, but I wanted to get the message out that I'm working on it for the 2018.10 release. :-)

### Issues/PRs references
Resolves #73 