### PR TITLE
task06: clarify port choice for 6.2

### DIFF
--- a/06-single-hop-udp/06-single-hop-udp.md
+++ b/06-single-hop-udp/06-single-hop-udp.md
@@ -18,8 +18,8 @@ Sending UDP between two iotlab-m3 nodes.
 <5% packets lost on the receiving node.
 No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
 
-Task #02 - UDP on iotlab-m3 (other port)
-========================================
+Task #02 - UDP on iotlab-m3 (UDP port compression)
+==================================================
 ### Description
 
 Sending UDP between two iotlab-m3 nodes.


### PR DESCRIPTION
Just noticed this while scanning over the currently ongoing tests: 61616 is not just "another port". It's within the port range of compressible ports for [6LoWPAN's UDP NHC][RFC6282].

[RFC6282]: https://tools.ietf.org/html/rfc6282#section-4.3.1