### PR TITLE
task4: change misleading title

### DIFF
--- a/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
+++ b/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
@@ -116,8 +116,8 @@ a samr21-xpro node.
 
 <10% packets lost on the pinging node.
 
-Task #08 (Experimental) - ICMPv6 echo with samr21-xpro/zero + xbee 15 minutes
-=============================================================================
+Task #08 (Experimental) - ICMPv6 echo with samr21-xpro/zero + xbee
+==================================================================
 ### Description
 
 ICMPv6 echo request/reply exchange between an Arduino Zero + XBee node and


### PR DESCRIPTION
The title of 4.8 is misleading, as the test doesn't run for 15 min.