### PR TITLE
[RFC/WIP]: Use pytest to run CoAP tasks

### DIFF
--- a/09-coap/.gitignore
+++ b/09-coap/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+assets

--- a/09-coap/coap.md
+++ b/09-coap/coap.md
@@ -1,0 +1,67 @@
+## Goal: Send/Receive typical CoAP messages
+
+Introduction
+============
+These tests exercise RIOT's CoAP implementations, [gcoap and nanocoap](https://github.com/RIOT-OS/RIOT/wiki/CoAP-Home). The tests are automated with the use of [pytest](https://pytest.org/).
+
+With all of these tests, your confidence in the results will increase by watching the CoAP messages in Wireshark.
+
+These tests all were developed using native on a recent Ubuntu Linux. However, they all may be run just as well on hardware.
+
+Materials
+---------
+
+In addition to pytest, you'll need a recent copy of these projects:
+
+* [aiocoap](https://github.com/chrysn/aiocoap)
+* [soscoap](https://github.com/kb2ma/soscoap)
+
+The _Setup_ section below assumes these projects are installed in source code form, not with pip or setup.py.
+
+Setup
+-----
+
+Some of these tests use a tap interface to communicate between a native RIOT instance and the Linux desktop. They require an fd00:bbbb::/64 ULA-based network defined on the desktop as:
+```
+    $ sudo ip address add fd00:bbbb::1/64 dev tap0 scope global
+```
+
+Some tests require environment variables. See `setup_env.sh`. You MUST adapt it to the paths on your machine, but then you can source it with:
+```
+    $ . setup_env.sh
+```
+As mentioned in the _Materials_ section, presently the script is based on installation of aiocoap and soscoap in source form.
+
+Running the tests
+-----------------
+You can run all tests in this directory with a single invocation of the standard `pytest` command. See the [usage documentation](https://docs.pytest.org/en/latest/usage.html) for variations.
+
+
+Task #01 - CORD Endpoint
+========================
+### Description
+
+gcoap client registers with an aiocoap CORE Resource Directory server.
+### Result
+
+Registration succeeds.
+
+### Details
+
+Exercises confirmable client messaging, including Uri-Query and Location-Path options.
+
+
+Task #02 - Confirmable retries
+==============================
+### Description
+
+gcoap retries CON GET requests to an soscoap server. The soscoap server is instrumented to ignore a configurable number of requests before responding with the expected ACK.
+
+### Result
+Results depend on the particular test. Either:
+
+* gcoap receives the server response and stops resending messages
+* gcoap does not receive a server response, gives up and reports the timeout.
+
+### Details
+gcoap attempts a maximum of four retries; five messages altogether including the initial request. The retries are timed with CoAP's exponential backoff mechanism.

--- a/09-coap/con_ignore_server.py
+++ b/09-coap/con_ignore_server.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+"""
+Provides a server that ignores a configurable number of confirmable message
+message attempts. Provides a /time resource.
+
+Usage:
+    usage: con_ignore_server.py [-h] -i IGNORES
+    optional arguments:
+      -h, --help  show this help message and exit
+      -i IGNORES  count of requests to ignore
+      
+Example:
+
+Ignores initial request and first retry. Responds on second retry.
+
+$ PYTHONPATH="/home/kbee/src/soscoap" ./con_ignore_server.py -i 2
+"""
+
+from   argparse import ArgumentParser
+import datetime
+from   soscoap.server   import CoapServer, IgnoreRequestException
+
+class ConIgnoreServer(object):
+    def __init__(self, ignores):
+        """Pass in count of confirmable messages to ignore."""
+        self._server = CoapServer(port=5683)
+        self._server.registerForResourceGet(self._getResource)
+        self._ignores = ignores
+
+    def _getResource(self, resource):
+        """Sets the value for the provided resource, for a GET request."""
+        if resource.path == '/time':
+            if self._ignores > 0:
+                self._ignores = self._ignores - 1
+                raise IgnoreRequestException
+                return
+            else:
+                resource.type  = 'string'
+                now = datetime.datetime.now()
+                resource.value = now.strftime("%Y-%m-%d %H:%M").encode('ascii')
+        else:
+            raise NotImplementedError('Unknown path')
+            return
+
+    def start(self):
+        self._server.start()
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('-i', dest='ignores', type=int,
+                        help='count of requests to ignore')
+
+    args = parser.parse_args()
+
+    server = ConIgnoreServer(args.ignores)
+    server.start()
+
+

--- a/09-coap/conftest.py
+++ b/09-coap/conftest.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+"""
+Utilities for tests
+"""
+
+import pytest
+import pexpect
+import os
+import signal
+import logging
+
+class ExpectHost():
+    """
+    A networking host wrapped in a pexpect spawn.
+
+    The pexpect spawn object itself is available as the 'term' attribute.
+    """
+
+    def __init__(self, folder, term_cmd, timeout=10):
+        self.folder = folder
+        self.term = None
+        self.term_cmd = term_cmd
+        self.timeout = timeout
+
+    def connect(self):
+        """
+        Starts OS host process.
+
+        :return: pexpect spawn object; the 'term' attribute for ExpectHost
+        """
+        if self.folder:
+            os.chdir(self.folder)
+        
+        self.term = pexpect.spawn(self.term_cmd, codec_errors='replace',
+                                  timeout=self.timeout)
+        return self.term
+
+    def disconnect(self):
+        """Kill OS host process"""
+        try:
+            os.killpg(os.getpgid(self.term.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            logging.info("Process already stopped")
+
+    def send_recv(self, out_text, in_text):
+        """Sends the given text to the host, and expects the given text
+           response."""
+        self.term.sendline(out_text)
+        self.term.expect(in_text, self.timeout)
+
+
+@pytest.fixture
+def gcoap_example():
+    """
+    Runs the RIOT gcoap CLI example as an ExpectHost.
+    """
+    base_folder = os.environ.get('RIOTBASE', None)
+
+    host = ExpectHost(os.path.join(base_folder, 'examples/gcoap'), 'make term')
+    term = host.connect()
+    term.expect('gcoap .* app')
+
+    # set ULA
+    host.send_recv('ifconfig 6 add unicast fd00:bbbb::2/64',
+                   'success:')
+    yield host
+
+    # teardown
+    host.disconnect()

--- a/09-coap/setup_env.sh
+++ b/09-coap/setup_env.sh
@@ -1,0 +1,9 @@
+# Environment variables for tests. Source this file before running them.
+#
+# Tests use environment variables rather than an INI file because it matches
+# how the tests also would be run from within RIOT.
+
+export RIOTBASE="/home/kbee/dev/riot/repo" 
+export AIOCOAP_BASE="/home/kbee/dev/aiocoap/repo"
+export SOSCOAP_BASE="/home/kbee/dev/soscoap/repo"
+export PYTHONPATH="${SOSCOAP_BASE}"

--- a/09-coap/test_01.py
+++ b/09-coap/test_01.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+"""
+Tests registration to a CORE Resource Directory server.
+
+Requires:
+   - RIOTBASE env variable for RIOT root directory
+
+   - AIOCOAP_BASE env variable for aiocoap root directory.
+
+   - Network with ULA fd00:bbbb::1/64
+"""
+
+import pytest
+import os
+import time
+
+from conftest import ExpectHost
+
+#
+# fixtures and utility functions
+#
+
+@pytest.fixture
+def cord_cli():
+    """Runs the RIOT cord_ep example process as an ExpectHost."""
+    base_folder = os.environ.get('RIOTBASE', None)
+
+    host = ExpectHost(os.path.join(base_folder, 'examples/cord_ep'), 'make term')
+    term = host.connect()
+    term.expect('CoRE RD client example!')
+
+    # set ULA
+    host.send_recv('ifconfig 7 add unicast fd00:bbbb::2/64',
+                   'success:')
+    yield host
+
+    # teardown
+    host.disconnect()
+
+
+@pytest.fixture
+def rd_server():
+    """Runs an aiocoap Resource Directory server as an ExpectHost."""
+    folder = os.environ.get('AIOCOAP_BASE', None)
+
+    host = ExpectHost(folder, './aiocoap-rd')
+    term = host.connect()
+    # allow a couple of seconds for initialization
+    time.sleep(2)
+    yield host
+
+    # teardown
+    host.disconnect()
+
+#
+# tests
+#
+
+def test_register(rd_server, cord_cli):
+
+    cord_cli.send_recv('cord_ep register [fd00:bbbb::1]',
+                       'registration successful')

--- a/09-coap/test_02.py
+++ b/09-coap/test_02.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2018 Ken Bannister. All rights reserved.
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+"""
+Tests CoAP confirmable message retry capability.
+
+Sends a GET request from gcoap to a server that ignores a configurable number
+of requests.
+
+Requires:
+   - RIOTBASE env variable for RIOT root directory
+
+   - SOSCOAP_BASE env variable for soscoap root directory.
+
+   - Network with ULA fd00:bbbb::1/64
+"""
+
+import pytest
+import os
+import pexpect
+import time
+import logging
+
+from conftest import ExpectHost
+
+logging.basicConfig(level=logging.INFO)
+
+pwd = os.getcwd()
+
+#
+# fixtures and utility functions
+#
+
+@pytest.fixture
+def retry_server(ignores):
+    """Runs a server that ignores requests as an ExpectHost."""
+
+    cmd = './con_ignore_server.py -i {0}'.format(ignores)
+
+    host = ExpectHost(pwd, cmd)
+    term = host.connect()
+    # allow a couple of seconds for initialization
+    time.sleep(2)
+    yield host
+
+    # teardown
+    host.disconnect()
+
+
+@pytest.fixture
+def ignores():
+    """Count of requests to ignore."""
+    return 0
+
+def send_recv(client):
+    # expects time value formatted like '2018-11-04 17:20'
+    client.send_recv('coap get -c fd00:bbbb::1 5683 /time',
+                     r'\d+-\d+-\d+ \d+:\d')
+
+#
+# tests
+#
+
+@pytest.mark.parametrize('ignores', [2])
+def test_recover(retry_server, gcoap_example, ignores):
+    """Recover from 2 ignored requests and receive time value."""
+    send_recv(gcoap_example)
+
+@pytest.mark.parametrize('ignores', [5])
+def test_timeout(retry_server, gcoap_example, ignores):
+    """Times out from 5 ignored requests."""
+    gcoap_example.timeout = 100
+    
+    with pytest.raises(pexpect.TIMEOUT):
+        send_recv(gcoap_example)


### PR DESCRIPTION
### Contribution description

This PR refines the experimental 09-CoAP tasks in #77 by using pytest to automate running the tasks. This PR also is a kind of RFC for use of pytest in RIOT. pytest provides a number of advantages for composing and running tests, and it provides an evolutionary path forward from RIOT's pexpect-based testrunner.

If you're not familiar with pytest, review the [documentation](https://docs.pytest.org/en/latest/contents.html) or some of the [presentations](https://docs.pytest.org/en/latest/talks.html) about it. The content of the tests in 09-coap are introduced in [coap.md](https://github.com/kb2ma/Release-Specs/blob/add_coap_pytest/09-coap/coap.md). I am a newbie to pytest myself, but we do use it at my employer.

#### [01_test.py](https://github.com/kb2ma/Release-Specs/blob/add_coap_pytest/09-coap/test_01.py) 
Runs an aiocoap-based Resource Directory server as a pytest [fixture](https://docs.pytest.org/en/latest/fixture.html) in rd_server(). Also runs the gcoap CORD client as a fixture. These fixtures include a generic class to run pexpect, ExpectHost, found in [conftest.py](https://github.com/kb2ma/Release-Specs/blob/add_coap_pytest/09-coap/conftest.py). They also use the capability for a fixture to include teardown code, which neatly packages this functionality with the setup code. 

Finally, the test itself in test_register() is a single function call. Notice that the fixtures are included in the test by passing them to the test function.

#### [02_test.py](https://github.com/kb2ma/Release-Specs/blob/add_coap_pytest/09-coap/test_02.py) 
Runs an soscoap server for its capability to short circuit responses to a confirmable request. The CoAP server is started in retry_server(), and the client is started in gcoap_example() in conftest.py, which allows for reuse in other tests.

The test functions also include an _ignores_ parameter to vary the number of confirmable requests to ignore. The value of the parameter is specified in the 'parametrize' decorator. pytest includes a few mechanisms for parameterization, as described in the fixture documentation. 

Finally, notice that the test_timeout function is able to simply modify the pexect timeout for this test. It also uses the pytest.raises() context manager function to mark that send_recv() is expected to timeout.

#### Other pytest features
pytest includes an extensive collection of [plugins](http://plugincompat.herokuapp.com/). Below you can see the output of the [pytest-html](https://pypi.org/project/pytest-html) plugin for a test run of 09-coap.

Thanks to @jia200x for his testutils PR #79, which inspired some of this work. Also thanks to @smlng and @MrKevinWeiss for [RIOT #10241](https://github.com/RIOT-OS/RIOT/issues/10241) and [RIOT #10095](https://github.com/RIOT-OS/RIOT/pull/10095) for Robot Framework.

![report](https://user-images.githubusercontent.com/2944058/48417813-b74cc980-e721-11e8-9a17-eed4ef520d7f.png)

### Issues/PRs references

This PR improves on #77 by automating the tasks.