### PR TITLE
02-tests:compile_and_test_for_board: allow setting 'all' and 'test'

### DIFF
--- a/02-tests/compile_and_test_for_board.py
+++ b/02-tests/compile_and_test_for_board.py
@@ -79,64 +79,6 @@ LOG_HANDLER.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 LOG_LEVELS = ('debug', 'info', 'warning', 'error', 'fatal', 'critical')
 
 
-def list_from_string(list_str=None):
-    """Get list of items from `list_str`
-
-    >>> list_from_string(None)
-    []
-    >>> list_from_string("")
-    []
-    >>> list_from_string("  ")
-    []
-    >>> list_from_string("a")
-    ['a']
-    >>> list_from_string("a  ")
-    ['a']
-    >>> list_from_string("a b  c")
-    ['a', 'b', 'c']
-    """
-    value = (list_str or '').split(' ')
-    return [v for v in value if v]
-
-
-def _strip_board_equal(board):
-    """Sanitizy board if given as BOARD=board.
-
-    Increase RIOT compatibility.
-    """
-    if board.startswith('BOARD='):
-        board = board.replace('BOARD=', '')
-    return board
-
-
-PARSER = argparse.ArgumentParser()
-PARSER.add_argument('riot_directory', help='RIOT directory to test')
-PARSER.add_argument('board', help='Board to test', type=_strip_board_equal)
-PARSER.add_argument('result_directory', nargs='?', default='results',
-                    help='Result directory, by default "results"')
-PARSER.add_argument(
-    '--applications', type=list_from_string,
-    help=('List of applications to test, overwrites default configuration of'
-          ' testing all applications'),
-)
-PARSER.add_argument(
-    '--applications-exclude', type=list_from_string,
-    help=('List of applications to exclude from tested applications.'
-          ' Also applied after "--applications".'),
-)
-PARSER.add_argument('--no-test', action='store_true', default=False,
-                    help='Disable executing tests')
-PARSER.add_argument('--loglevel', choices=LOG_LEVELS, default='info',
-                    help='Python logger log level, defauts to "info"')
-PARSER.add_argument('--incremental', action='store_true', default=False,
-                    help='Do not rerun successful compilation and tests')
-PARSER.add_argument('--clean-after', action='store_true', default=False,
-                    help='Clean after running each test')
-PARSER.add_argument(
-    '--jobs', '-j', type=int, default=None,
-    help="Parallel building (0 means not limit, like '--jobs')")
-
-
 class TestError(Exception):
     """Custom exception for a failed test.
 
@@ -553,6 +495,67 @@ def save_failure_summary(resultdir, summary):
 
     with open(outfile, 'w+', encoding='utf-8', errors='replace') as outputfd:
         outputfd.write(summary)
+
+
+# Parsing functions
+
+
+def list_from_string(list_str=None):
+    """Get list of items from `list_str`
+
+    >>> list_from_string(None)
+    []
+    >>> list_from_string("")
+    []
+    >>> list_from_string("  ")
+    []
+    >>> list_from_string("a")
+    ['a']
+    >>> list_from_string("a  ")
+    ['a']
+    >>> list_from_string("a b  c")
+    ['a', 'b', 'c']
+    """
+    value = (list_str or '').split(' ')
+    return [v for v in value if v]
+
+
+def _strip_board_equal(board):
+    """Sanitizy board if given as BOARD=board.
+
+    Increase RIOT compatibility.
+    """
+    if board.startswith('BOARD='):
+        board = board.replace('BOARD=', '')
+    return board
+
+
+PARSER = argparse.ArgumentParser()
+PARSER.add_argument('riot_directory', help='RIOT directory to test')
+PARSER.add_argument('board', help='Board to test', type=_strip_board_equal)
+PARSER.add_argument('result_directory', nargs='?', default='results',
+                    help='Result directory, by default "results"')
+PARSER.add_argument(
+    '--applications', type=list_from_string,
+    help=('List of applications to test, overwrites default configuration of'
+          ' testing all applications'),
+)
+PARSER.add_argument(
+    '--applications-exclude', type=list_from_string,
+    help=('List of applications to exclude from tested applications.'
+          ' Also applied after "--applications".'),
+)
+PARSER.add_argument('--no-test', action='store_true', default=False,
+                    help='Disable executing tests')
+PARSER.add_argument('--loglevel', choices=LOG_LEVELS, default='info',
+                    help='Python logger log level, defauts to "info"')
+PARSER.add_argument('--incremental', action='store_true', default=False,
+                    help='Do not rerun successful compilation and tests')
+PARSER.add_argument('--clean-after', action='store_true', default=False,
+                    help='Clean after running each test')
+PARSER.add_argument(
+    '--jobs', '-j', type=int, default=None,
+    help="Parallel building (0 means not limit, like '--jobs')")
 
 
 def main():

--- a/02-tests/compile_and_test_for_board.py
+++ b/02-tests/compile_and_test_for_board.py
@@ -530,7 +530,8 @@ def _strip_board_equal(board):
     return board
 
 
-PARSER = argparse.ArgumentParser()
+PARSER = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 PARSER.add_argument('riot_directory', help='RIOT directory to test')
 PARSER.add_argument('board', help='Board to test', type=_strip_board_equal)
 PARSER.add_argument('result_directory', nargs='?', default='results',


### PR DESCRIPTION
Allow overwriting compile 'clean all' and 'test' commands.
    
This will allow running for example 'scan-build-analyze' for building
and also other test commands like 'robottest', 'pytest',
'archive-check' as currently exist in some PRs.
    
It still currently hardwritten how to finding if there is a test
as it is not integrated in RIOT or if a board is supported for the
application.

It also required the two first commits to move PARSER at the end and print the default value in help messages to make in understandable by users what goes in '--compile-targets'.


### Testing procedure

Overwrite the compile command with for example `distclean all`.

```
./compile_and_test_for_board.py --applications="tests/bloom_bytes" --compile-targets="distclean all"  --loglevel=debug ~/work/git/RIOT native
INFO:native:Saving toolchain
DEBUG:native:board: native
DEBUG:native:app_dirs: ['tests/bloom_bytes']
DEBUG:native:resultdir: results
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'info-boards-supported'] ENV {'BOARDS': 'native', 'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board supported: True
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'info-debug-variable-BOARD_INSUFFICIENT_MEMORY'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board has enough memory: True
INFO:native.tests/bloom_bytes:Run compilation
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'distclean', 'all'] ENV {'BOARD': 'native'}
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', '--silent', 'info-debug-variable-TESTS'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Run test
INFO:native.tests/bloom_bytes:Run test.flash
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'flash-only'] ENV {'BOARD': 'native'}
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'test'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Success
INFO:native:Tests successful
```

and the test targets with for example `info-build tests`

```
/compile_and_test_for_board.py --applications="tests/bloom_bytes" --test-targets="info-build test"  --loglevel=debug ~/work/git/RIOT native
INFO:native:Saving toolchain
DEBUG:native:board: native
DEBUG:native:app_dirs: ['tests/bloom_bytes']
DEBUG:native:resultdir: results
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'info-boards-supported'] ENV {'BOARDS': 'native', 'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board supported: True
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'info-debug-variable-BOARD_INSUFFICIENT_MEMORY'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board has enough memory: True
INFO:native.tests/bloom_bytes:Run compilation
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'clean', 'all'] ENV {'BOARD': 'native'}
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', '--silent', 'info-debug-variable-TESTS'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Run test
INFO:native.tests/bloom_bytes:Run test.flash
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'flash-only'] ENV {'BOARD': 'native'}
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', '/home/harter/work/git/RIOT/tests/bloom_bytes', 'info-build', 'test'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Success
INFO:native:Tests successful
```

You can see the updated executed command in the help message.


I can not currently really show other examples as there are issues with the `scan-build` integration and no other `test` commands in RIOT for the moment.


### Issues reference

Should help testing the new tests integration on all applications and also running `scan-build` on the whole codebase easily (after being fixed).

This would be a nice use for https://github.com/RIOT-OS/RIOT/pull/10391