### PR TITLE
02-task/compile_and_test: add option that print errors on terminal

### DIFF
--- a/02-tests/compile_and_test_for_board.py
+++ b/02-tests/compile_and_test_for_board.py
@@ -413,6 +413,7 @@ class RIOTApplication():
         output += 'Return value: %s\n' % err.returncode
         outfile = self._write_resultfile(name, 'failed', output)
 
+        self.logger.warning(output)
         self.logger.error('Error during %s, writing to %s', name, outfile)
         raise TestError(name, self, outfile)
 


### PR DESCRIPTION
This PR adds a new `--print-error` option to the compile_and_test script: the idea is to have any error raised by make to be written in the log file but also on the stdout while running a test.

Example (with a failing make test on pkg_cayenne-lpp):
```
./compile_and_test_for_board.py ../../RIOT native --applications tests/pkg_cayenne-lpp --print-error
INFO:native:Saving toolchain
INFO:native.tests/pkg_cayenne-lpp:Board supported: True
INFO:native.tests/pkg_cayenne-lpp:Board has enough memory: True
INFO:native.tests/pkg_cayenne-lpp:Run compilation
INFO:native.tests/pkg_cayenne-lpp:Run test
INFO:native.tests/pkg_cayenne-lpp:Run test.flash
ERROR:native.tests/pkg_cayenne-lpp:Error during test, writing to results/native/tests/pkg_cayenne-lpp/test.failed
ERROR:native.tests/pkg_cayenne-lpp:make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C ../../RIOT/tests/pkg_cayenne-lpp test
make[1]: Nothing to be done for 'Makefile.include'.
make[2]: Nothing to be done for 'Makefile.include'.
/home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf   
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Cayenne LPP test application

Test 1:
-------
Result: 03670110056700FF SUCCESS

Test 2:
-------
Result: 0167FFD8067104D1FB2F0000
Expected: 0167FFD8067104D1FB2F0002 FAILED
Timeout in expect script at "child.expect('Result: [0-9A-Z]+ SUCCESS', timeout=5)" (tests/pkg_cayenne-lpp/tests/01-run.py:12)

/home/aabadie/softs/src/riot/RIOT/tests/pkg_cayenne-lpp/../../Makefile.include:560: recipe for target 'test' failed
make: *** [test] Error 1

Return value: 2

ERROR:native.tests/pkg_cayenne-lpp:Failed during: test
ERROR:native:Tests failed: 1
Failures during test:
- [tests/pkg_cayenne-lpp](tests/pkg_cayenne-lpp/test.failed)
```