### PR TITLE
06-single-hop-udp: Remove channel for native

### DIFF
--- a/06-single-hop-udp/06-single-hop-udp.md
+++ b/06-single-hop-udp/06-single-hop-udp.md
@@ -42,7 +42,6 @@ Task #03 - UDP on native (non-existent neighbor)
 
 Sending UDP from one native node to a non-existent neighbor.
 * Stack configuration:    IPv6 (default)
-* Channel:                26
 * Count:                  1000
 * Interval:               0us
 * Port:                   1337


### PR DESCRIPTION
This removes the `channel` configuration for the single hop UDP test on native, which is not applicable.