### PR TITLE
task10: add requirement for MTU field of Packet Too Big message

### DIFF
--- a/10-icmpv6-error/10-icmpv6-error.md
+++ b/10-icmpv6-error/10-icmpv6-error.md
@@ -238,6 +238,7 @@ hop link but not the second hop link via a native node from a Linux host.
 ### Result
 
 An ICMPv6 packet too big (code: 0) message should be sent by the native node.
+The MTU field of the ICMPv6 packet too big message must have a value of 1280.
 The payload of the original packet carried in the ICMPv6 message should be
 truncated to fit the TAP interface's MTU.
 

--- a/10-icmpv6-error/10-icmpv6-error.md
+++ b/10-icmpv6-error/10-icmpv6-error.md
@@ -237,7 +237,7 @@ hop link but not the second hop link via a native node from a Linux host.
 
 ### Result
 
-An ICMPv6 packet to big (code: 0) message should be sent by the native node.
+An ICMPv6 packet too big (code: 0) message should be sent by the native node.
 The payload of the original packet carried in the ICMPv6 message should be
 truncated to fit the TAP interface's MTU.
 


### PR DESCRIPTION
Since the MTU field of a Packet Too Big message is quite important for Path MTU Discovery (see [RFC 8201](https://tools.ietf.org/html/rfc8201)) we should check its value in our release tests.