### PR TITLE
task10: fix interface switch up

### DIFF
--- a/10-icmpv6-error/10-icmpv6-error.md
+++ b/10-icmpv6-error/10-icmpv6-error.md
@@ -138,11 +138,11 @@ misconfigured route on the native node from a Linux host.
 
 3. Add `beef::/64` route via TAP interface on RIOT side:
 
-        > nib route add 7 beef::/64 "<TAP interface link-local IPv6 address>"
+        > nib route add 6 beef::/64 "<TAP interface link-local IPv6 address>"
 
 4. Add `affe::/64` route via not existing node `fe80::1` on RIOT side:
 
-        > nib route add 8 affe::/64 "fe80::1"
+        > nib route add 6 affe::/64 "fe80::1"
 
 5. Send the UDP packet as specified.
 
@@ -227,11 +227,11 @@ hop link but not the second hop link via a native node from a Linux host.
 
 4. Add `beef::/64` route via TAP interface on RIOT side:
 
-        > nib route add 6 beef::/64 "<TAP interface link-local IPv6 address>"
+        > nib route add 7 beef::/64 "<TAP interface link-local IPv6 address>"
 
 5. Add `affe::/64` route via not existing node `fe80::1` on RIOT side:
 
-        > nib route add 6 affe::/64 "fe80::1"
+        > nib route add 8 affe::/64 "fe80::1"
 
 6. Send the UDP packet as specified.
 


### PR DESCRIPTION
When fixing the interfaces in https://github.com/RIOT-OS/Release-Specs/pull/93 I accidentally changed them for the wrong task. Task 4 is compiled normally, so the application doesn't have any additional interfaces or a 6Lo thread. Task 7 is compiled with `socket_zep` included, so its interface identifiers are different.