### PR TITLE
Adapt for new ping6 command

### DIFF
--- a/07-multi-hop/IOTLABHelper.py
+++ b/07-multi-hop/IOTLABHelper.py
@@ -209,8 +209,8 @@ class IOTLABHelper:
 
     def ping(self, ip, nodeType, node, pingCount, pingPayloadSz, pingDelay):
         print("Pinging ({0}) for node {1}-{2} ... ".format(ip, nodeType, node[0]), end="")
-        self.testbed.sendline("{0}-{1};ping6 {2} {3} {4} {5}".format(nodeType, node[0], pingCount,
-                              ip, pingPayloadSz, pingDelay))
+        self.testbed.sendline("{0}-{1};ping6 -c {2} -s {3} -i {4} {5}".format(
+            nodeType, node[0], pingCount, pingPayloadSz, pingDelay, ip))
         if self.testbed.expect([pexpect.TIMEOUT, " ([0-9][0-9]?)% packet loss"], timeout=10) != 0:
             print("success with {0}% packet loss".format(self.testbed.match.group(1)))
             return True

--- a/07-multi-hop/example_test_guide.md
+++ b/07-multi-hop/example_test_guide.md
@@ -30,8 +30,8 @@ ICMPv6 echo request/reply exchange between two iotlab-m3 nodes over three hops
 with static routes.
 
 1. Follow Task 1 and 2 setup
-2. Ping node 4 from node 1, Node 1:`ping6 100 abcd::2 50 100`
-3. Ping node 1 from node 4, Node 4:`ping6 100 abcd::1 50 100`
+2. Ping node 4 from node 1, Node 1:`ping6 -c 100 -s 50 -i 100 abcd::2`
+3. Ping node 1 from node 4, Node 4:`ping6 -c 100 -s 50 -i 100 abcd::1`
 
 ### Result
 
@@ -87,8 +87,8 @@ ICMPv6 echo request/reply exchange between two iotlab-m3 nodes over three hops
 with RPL generated routes.
 
 1. Follow Task 3 and 4 setup
-2. Ping >3 hop node from root node, Node 1:`ping6 100 abcd::<other node global address> 50 100`
-2. Ping root node from other node, Node 4:`ping6 100 abcd::1 50 100`
+2. Ping >3 hop node from root node, Node 1:`ping6 -c 100 -s 50 -i 100 abcd::<other node global address>`
+2. Ping root node from other node, Node 4:`ping6 -c 100 -s 50 -i 100 abcd::1`
 
 ### Result
 


### PR DESCRIPTION
With https://github.com/RIOT-OS/RIOT/pull/9523 the syntax of `ping6` slightly changed. This fixes all occurrences of this in this Repo so far.

**do not merge before testing for 2019.01 is finished** (this only affects 2019.04).