### PR TITLE
task07: remove redundant ping

### DIFF
--- a/07-multi-hop/example_test_guide.md
+++ b/07-multi-hop/example_test_guide.md
@@ -31,7 +31,6 @@ with static routes.
 
 1. Follow Task 1 and 2 setup
 2. Ping node 4 from node 1, Node 1:`ping6 -c 100 -s 50 -i 100 abcd::2`
-3. Ping node 1 from node 4, Node 4:`ping6 -c 100 -s 50 -i 100 abcd::1`
 
 ### Result
 
@@ -87,7 +86,6 @@ ICMPv6 echo request/reply exchange between two iotlab-m3 nodes over three hops
 with RPL generated routes.
 
 1. Follow Task 3 and 4 setup
-2. Ping >3 hop node from root node, Node 1:`ping6 -c 100 -s 50 -i 100 abcd::<other node global address>`
 2. Ping root node from other node, Node 4:`ping6 -c 100 -s 50 -i 100 abcd::1`
 
 ### Result


### PR DESCRIPTION
This is more of an RFC. I think the second ping command is redundant, since the ping exchange is already bidirectional (so compared to UDP we don't have to check "the other direction"). However, I see the benefit in having a redundant ping from the other end to mitigate errors in the setup.