### PR TITLE
task04: change timings for large payload test

### DIFF
--- a/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
+++ b/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
@@ -40,7 +40,7 @@ ICMPv6 echo request/reply exchange between two nodes.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                26
 * Count:                  500
-* Interval:               200ms
+* Interval:               300ms
 * Payload:                1kB
 * Destination Address:    Link local unicast (fe80::.../64)
 

--- a/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
+++ b/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
@@ -39,8 +39,8 @@ Task #03 - ICMPv6 echo with large payload
 ICMPv6 echo request/reply exchange between two nodes.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                26
-* Count:                  1000
-* Interval:               100ms
+* Count:                  500
+* Interval:               200ms
 * Payload:                1kB
 * Destination Address:    Link local unicast (fe80::.../64)
 


### PR DESCRIPTION
Due to fragmentation the average round trip time of a link-local ping
is about 140ms (depending on distance). This puts a strain on both
packet buffer and reassembly buffer on the sending nodes as it has to
handle at least two packets while it is also working on a reply.

Add to that that the `at86rf2xx` driver is only able to send when it is
not in receive state (and blocks until it leaves) the pinged node has
problems to get out the data it wants to send the echo replies while it
is being spammed with fragments containing follow-up echo requests.

Because the test is mainly about testing fragmentation, not
fragmentation under stress, I suggest we tweak the test parameters a
bit so the test takes the same time, but with less stress on the node.

Also see https://github.com/RIOT-OS/Release-Specs/issues/113#issuecomment-481733314