### PR TITLE
task05: increase timing for large payload tests

### DIFF
--- a/05-single-hop-route/05-single-hop-route.md
+++ b/05-single-hop-route/05-single-hop-route.md
@@ -33,7 +33,7 @@ different prefix. A static default route has to be used
 advertisements for this task).
 * Stack configuration: IPv6 (default)
 * Count:                  100
-* Interval:               10ms
+* Interval:               300ms
 * Payload:                1kB
 * Sender address:         affe::1/120
 * Destination Address:    beef::1/64
@@ -76,7 +76,7 @@ router advertisements on both ends *beforehand* with `ifconfig <iface> -rtr_adv`
 otherwise default routes and address resolution will be auto-configured ).
 * Stack configuration: IPv6 (default)
 * Count:                  10
-* Interval:               10ms
+* Interval:               300ms
 * Payload:                1kB
 * Destination Address:    beef::1/64
 


### PR DESCRIPTION
Due to fragmentation the average round trip time of a link-local ping
is about 140ms (depending on distance). This puts a strain on both
packet buffer and reassembly buffer on the sending nodes as it has to
handle at least two packets while it is also working on a reply.

Add to that that the `at86rf2xx` driver is only able to send when it is
not in receive state (and blocks until it leaves) the pinged node has
problems to get out the data it wants to send the echo replies while it
is being spammed with fragments containing follow-up echo requests.

This test is about being able to route packets without packet loss, not
whether this process can happen under stress. Therefore there is no
penalty in relaxing the timings as much as necessary, apart from a
longer test time.