### PR TITLE
02-tests: Specify that tapsetup should be run first

### DIFF
--- a/02-tests/02-tests.md
+++ b/02-tests/02-tests.md
@@ -2,8 +2,8 @@
 
 ### Usage
 
-Run `RIOT/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py`
-script with your test board connected.
+Firstly, run the tapsetup tool in dist/tools/tapsetup. Then, Run 02
+`compile_and_test_for_board.py` script with your test board connected.
 
 See `RIOT/dist/tools/compile_and_test_for_board/README.md` and script `--help`
 for usage.


### PR DESCRIPTION
This prevents the test engineer from running the tests and then
realising that the test requires the tap bridge to be up.

Reopen of #125.