### PR TITLE
specs/03: Update 03-single-hop-ipv6-icmp readme

### DIFF
--- a/03-single-hop-ipv6-icmp/03-single-hop-ipv6-icmp.md
+++ b/03-single-hop-ipv6-icmp/03-single-hop-ipv6-icmp.md
@@ -54,7 +54,7 @@ Rapid ICMPv6 echo request/reply exchange from 10 host ping applications (same
 host, e.g. Linux host) simultaneously to one native node for 1 hour.
 
 * Stack configuration: IPv6 (default)
-* Count:                  100000
+* Count:                  Infinity
 * Interval:               0ms
 * Payload:                1452B
 * Destination Address:    Link local unicast (fe80::.../64)

--- a/03-single-hop-ipv6-icmp/03-single-hop-ipv6-icmp.md
+++ b/03-single-hop-ipv6-icmp/03-single-hop-ipv6-icmp.md
@@ -52,7 +52,6 @@ This tests will require `CFLAGS=-DGNRC_IPV6_NIB_NUMOF=10` to run.
 
 Rapid ICMPv6 echo request/reply exchange from 10 host ping applications (same
 host, e.g. Linux host) simultaneously to one native node for 1 hour.
-
 * Stack configuration: IPv6 (default)
 * Count:                  Infinity
 * Interval:               0ms

--- a/03-single-hop-ipv6-icmp/03-single-hop-ipv6-icmp.md
+++ b/03-single-hop-ipv6-icmp/03-single-hop-ipv6-icmp.md
@@ -48,27 +48,11 @@ ICMPv6 echo request/reply exchange between two native nodes.
 Task #04 - ICMPv6 stress test on native (1 hour)
 ================================================
 ### Description
+This tests will require `CFLAGS=-DGNRC_IPV6_NIB_NUMOF=10` to run.
 
 Rapid ICMPv6 echo request/reply exchange from 10 host ping applications (same
 host, e.g. Linux host) simultaneously to one native node for 1 hour.
-* Stack configuration: IPv6 (default)
-* Count:                  Infinity
-* Interval:               0ms
-* Payload:                1452B
-* Destination Address:    Link local unicast (fe80::.../64)
 
-### Result
-
-All nodes are still running, reachable, and the packet buffer is empty 10
-seconds after completions (use module `gnrc_pktbuf_cmd`).
-Packet loss is irrelevant in this stress test.
-
-Task #05 - ICMPv6 stress test on native (neighbor cache stress)
-===============================================================
-### Description
-
-Rapid ICMPv6 echo request/reply exchange from 10 native nodes simultaneously to
-one native node.
 * Stack configuration: IPv6 (default)
 * Count:                  100000
 * Interval:               0ms
@@ -80,3 +64,25 @@ one native node.
 All nodes are still running, reachable, and the packet buffer is empty 10
 seconds after completions (use module `gnrc_pktbuf_cmd`).
 Packet loss is irrelevant in this stress test.
+For regression sake currently the 0ms ping6 has `~10% packet loss`.
+
+Task #05 - ICMPv6 stress test on native (neighbor cache stress)
+===============================================================
+### Description
+
+This tests will require `CFLAGS=-DGNRC_IPV6_NIB_NUMOF=10` to run.
+Rapid ICMPv6 echo request/reply exchange from 10 native nodes simultaneously to
+one native node.
+* Stack configuration: IPv6 (default)
+* Count:                  100000
+* Interval:               0ms/1ms
+* Payload:                1452B
+* Destination Address:    Link local unicast (fe80::.../64)
+
+### Result
+
+All nodes are still running, reachable, and the packet buffer is empty 10
+seconds after completions (use module `gnrc_pktbuf_cmd`).
+Packet loss is irrelevant in this stress test.
+For regression sake currently the 0ms ping6 has `100% packet loss`.
+The 1ms ping6 has `~25% packet loss`


### PR DESCRIPTION
It seems the stress tests cause some crashes because the default `GNRC_IPV6_NIB_NUMOF` must be increased for the `tests/gnrc_udp`.

Also some information is added for regression purposes.