### PR TITLE
04-single-hop-6lowpan-icmp: change task08 interval to 350ms

### DIFF
--- a/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
+++ b/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md
@@ -125,7 +125,7 @@ a samr21-xpro node.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                26
 * Count:                  1000
-* Interval:               100ms
+* Interval:               350ms
 * Payload:                100B
 * Destination Address:    Link local unicast (fe80::.../64)
 


### PR DESCRIPTION
This PR does two things:

- homologate examples_test_guide.md and specs
- change payload to work with default 9600 xbee baudrate

I changed the payload since form what I was able to test in 2020.01 and 2019.10 `xbee` can't handle100b payload at 100ms interval.

## Testing procedure

- Run the old spec on 2020.01 and 2019.10
- Run the new spec on 2020.01 and 2019.10