### PR TITLE
11-lorawan: Fix task numeration

### DIFF
--- a/11-lorawan/11-lorawan.md
+++ b/11-lorawan/11-lorawan.md
@@ -124,7 +124,7 @@ The device doesn't hang: the shell is responsive after the send/receive is
 finished.
 
 
-Task #03 - LoRaWAN device parameters persistence
+Task #04 - LoRaWAN device parameters persistence
 ================================================
 
 ### Description


### PR DESCRIPTION
This just fixes the numeration of the last LoRaWAN task, as it was duplicated.