### PR TITLE
08-interop: deprecate 9-10

### DIFF
--- a/08-interop/08-interop.md
+++ b/08-interop/08-interop.md
@@ -154,21 +154,7 @@ Link-local UDP over IPv6 packet exchange (payload length 8) between an iotlab-m3
 node running RIOT with GNRC and an iotlab-m3 node running RIOT with lwIP (in
 both directions).
 
-Task #09 - UDP between GNRC and emb6 on iotlab-m3
-=================================================
-### Description
-
-Link-local UDP over IPv6 packet exchange (payload length 8) between an iotlab-m3
-node running RIOT with GNRC and an iotlab-m3 node running RIOT with emb6.
-
-
-Task #10 - UDP between lwIP and emb6 on iotlab-m3
-=================================================
-### Description
-
-Link-local UDP over IPv6 packet exchange (payload length 8) between an iotlab-m3
-node running RIOT with lwIP and an iotlab-m3 node running RIOT with emb6 (in
-both directions).
+Task #09-#10 deprecated
 
 Task #11 - UDP exchange between iotlab-m3 and Zephyr
 =====================================================

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ following information must be given for each task:
 - a precise list of passing/failing criteria, so that there is no doubt if a
   task was successful or not
 
+#### Missing a test or wondering why it got replaced?
+
+The table in [REPLACED.md] documents for which release tests got deprecated and when
+they are to be replaced and by what.
+
 ### Test scripts and applications
 
 Each release specification should be accompanied by supporting scripts (and RIOT

--- a/REPLACED.md
+++ b/REPLACED.md
@@ -1,0 +1,6 @@
+# Replaced and deprecated tasks
+
+Full task name | Reason | Last release tested | Replaceable after | Replaced by
+-------------: | :----- | :-------: | ----------------: | :----------
+8.9 UDP between GNRC and emb6 on iotlab-m3 | [`emb6` package removed](https://github.com/RIOT-OS/RIOT/pull/14494) | 2020.04 | 2021-05-01 | TBA
+8.10 UDP between lwIP and emb6 on iotlab-m3 | [`emb6` package removed](https://github.com/RIOT-OS/RIOT/pull/14494) | 2020.04 | 2021-05-01 | TBA


### PR DESCRIPTION
`emb6` was deprecated in https://github.com/RIOT-OS/RIOT/pull/12389 and removed in https://github.com/RIOT-OS/RIOT/pull/14494 so it does not make much sense to test this anymore, even for 2020.07

Resolves #141 