### PR TITLE
05-single-hop-route: initial import of automated tests

### DIFF
--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -1,0 +1,131 @@
+import time
+
+import pytest
+
+from riotctrl_shell.gnrc import GNRCICMPv6Echo, GNRCIPv6NIB, GNRCPktbufStats
+from riotctrl_shell.netif import Ifconfig
+
+from testutils.native import bridged
+from testutils.shell import ping6, pktbuf, lladdr
+
+
+APP = 'examples/gnrc_networking'
+pytestmark = pytest.mark.rc_only()
+
+
+class Shell(Ifconfig, GNRCICMPv6Echo, GNRCPktbufStats, GNRCIPv6NIB):
+    pass
+
+
+@pytest.mark.skipif(not bridged(["tap0", "tap1"]),
+                    reason="tap0 and tap1 not bridged")
+# nodes passed to riot_ctrl fixture
+@pytest.mark.parametrize('nodes',
+                         [pytest.param(['native', 'native'])],
+                         indirect=['nodes'])
+def test_task01(riot_ctrl):
+    pinger, pinged = (
+        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap0"),
+        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap1"),
+    )
+
+    pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
+    pinged.ifconfig_flag(pinged_netif, "rtr_adv", False)
+    pinged.ifconfig_add(pinged_netif, "beef::1/64")
+    pinger_netif, pinger_lladdr = lladdr(pinger.ifconfig_list())
+    pinger.ifconfig_flag(pinger_netif, "rtr_adv", False)
+    pinger.ifconfig_add(pinger_netif, "beef::2/64")
+
+    pinged.nib_route_add(pinged_netif, "::", pinger_lladdr)
+    pinger.nib_route_add(pinger_netif, "::", pinged_lladdr)
+
+    res = ping6(pinger, "beef::1",
+                count=100, interval=10, packet_size=1024)
+    assert res['stats']['packet_loss'] < 1
+
+    assert pktbuf(pinged).is_empty()
+    assert pktbuf(pinger).is_empty()
+
+
+@pytest.mark.iotlab_creds
+@pytest.mark.parametrize('nodes',
+                         [pytest.param(['iotlab-m3', 'iotlab-m3'])],
+                         indirect=['nodes'])
+def test_task02(riot_ctrl):
+    pinger, pinged = (
+        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+    )
+
+    pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
+    pinged.ifconfig_add(pinged_netif, "beef::1/64")
+    pinger_netif, pinger_lladdr = lladdr(pinger.ifconfig_list())
+    pinger.ifconfig_add(pinger_netif, "affe::1/120")
+
+    pinged.nib_route_add(pinged_netif, "::", pinger_lladdr)
+    pinger.nib_route_add(pinger_netif, "::", pinged_lladdr)
+
+    res = ping6(pinger, "beef::1",
+                count=100, interval=300, packet_size=1024)
+    assert res['stats']['packet_loss'] < 10
+
+    time.sleep(10)
+    assert pktbuf(pinged).is_empty()
+    assert pktbuf(pinger).is_empty()
+
+
+@pytest.mark.skipif(not bridged(["tap0", "tap1"]),
+                    reason="tap0 and tap1 not bridged")
+@pytest.mark.parametrize('nodes',
+                         [pytest.param(['native', 'native'])],
+                         indirect=['nodes'])
+def test_task03(riot_ctrl):
+    pinger, pinged = (
+        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap0"),
+        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap1"),
+    )
+
+    pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
+    pinged.ifconfig_flag(pinged_netif, "rtr_adv", False)
+    pinged.ifconfig_add(pinged_netif, "beef::1/64")
+    pinger_netif, pinger_lladdr = lladdr(pinger.ifconfig_list())
+    pinger.ifconfig_flag(pinger_netif, "rtr_adv", False)
+    pinger.ifconfig_add(pinger_netif, "beef::2/64")
+
+    pinged.nib_route_add(pinged_netif, "beef::/64", pinger_lladdr)
+    pinger.nib_route_add(pinger_netif, "beef::/64", pinged_lladdr)
+
+    res = ping6(pinger, "beef::1",
+                count=10, interval=10, packet_size=1024)
+    assert res['stats']['packet_loss'] < 1
+
+    assert pktbuf(pinged).is_empty()
+    assert pktbuf(pinger).is_empty()
+
+
+@pytest.mark.skipif(not bridged(["tap0", "tap1"]),
+                    reason="tap0 and tap1 not bridged")
+@pytest.mark.parametrize('nodes',
+                         [pytest.param(['native', 'native'])],
+                         indirect=['nodes'])
+def test_task04(riot_ctrl):
+    pinger, pinged = (
+        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap0"),
+        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap1"),
+    )
+
+    pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
+    pinged.ifconfig_flag(pinged_netif, "rtr_adv", False)
+    pinged.ifconfig_add(pinged_netif, "beef::1/64")
+    pinger_netif, pinger_lladdr = lladdr(pinger.ifconfig_list())
+    pinger.ifconfig_flag(pinger_netif, "rtr_adv", False)
+
+    pinged.nib_route_add(pinged_netif, "::", pinger_lladdr)
+    pinger.nib_route_add(pinger_netif, "::", pinged_lladdr)
+
+    res = ping6(pinger, "beef::1",
+                count=10, interval=300, packet_size=1024)
+    assert res['stats']['packet_loss'] < 1
+
+    assert pktbuf(pinged).is_empty()
+    assert pktbuf(pinger).is_empty()


### PR DESCRIPTION
Taken out of the original #155, this provides automated tests (where possible with the current framework) for spec 5 to the new, pytest-based framework.

Requires #155