### PR TITLE
gh-actions: add workflow for release tests 

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,190 @@
+name: Release tests
+
+on:
+  schedule:
+    - cron: '0 3 * * 6'
+  workflow_dispatch:
+    inputs:
+      riot_version:
+        description: 'RIOT version to checkout'
+        required: true
+        default: 'master'
+      docker_version:
+        description: 'riot/riotbuild docker image version'
+        required: true
+        default: 'latest'
+
+# split up native and IoT-LAB tasks to parallelize somewhat and prevent
+# to hit Github Limit of 6h per job
+jobs:
+  native-tasks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - name: Generate .riotgithubtoken
+      run: |
+        echo '${{ secrets.ACCESS_TOKEN }}' > ~/.riotgithubtoken
+    - name: Checkout Release-Specs
+      uses: actions/checkout@v2
+      with:
+        path: Release-Specs
+    - name: Checkout RIOT
+      uses: actions/checkout@v2
+      with:
+        repository: RIOT-OS/RIOT
+        path: RIOT
+        fetch-depth: 1
+        ref: ${{ github.event.inputs.riot_version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions junit2html
+    - name: Pull riotbuild docker image
+      run: |
+        DOCKER_VERSION="${{ github.event.inputs.docker_version }}"
+        if [ -z "$DOCKER_VERSION" ]; then
+          DOCKER_VERSION="latest"
+        fi
+        docker pull riot/riotbuild:$DOCKER_VERSION
+    - name: Create TAP interfaces
+      run: |
+        sudo RIOT/dist/tools/tapsetup/tapsetup -c 11
+    - name: Run release tests
+      timeout-minutes: 350
+      run: |
+        RIOTBASE="$GITHUB_WORKSPACE/RIOT"
+        TOX_ARGS=""
+        if ! echo ${{ github.event.inputs.riot_version }} | \
+              grep -q "[0-9]\{4\}.[0-9]\{2\}-RC[0-9]\+"; then
+          TOX_ARGS+="--non-RC "
+        fi
+        CORES=$(cat /proc/cpuinfo | grep 'processor\s*:\s*[0-9]\+' | wc -l)
+        DOCKER_MAKE_ARGS="-j${CORES}"
+
+        cd Release-Specs
+        # definition in env does not work since $GITHUB_WORKSPACE seems not to
+        # be accessible
+        sudo \
+          BUILD_IN_DOCKER=1 \
+          DOCKER_MAKE_ARGS=${DOCKER_MAKE_ARGS} \
+          DOCKER_ENV_VARS=USEMODULE \
+          GITHUB_REPOSITORY=${GITHUB_REPOSITORY} \
+          GITHUB_RUN_ID=${GITHUB_RUN_ID} \
+          GITHUB_SERVER_URL=${GITHUB_SERVER_URL} \
+          RIOTBASE=${RIOTBASE} \
+          $(which tox) -- ${TOX_ARGS} -m "not iotlab_creds"
+    - name: junit2html and XML deploy
+      if: ${{ always() }}
+      run: |
+        DATE=$(date +"%Y-%m-%d-%H-%M-%S")
+        if echo ${{ github.event.inputs.riot_version }} | \
+              grep -q "[0-9]\{4\}.[0-9]\{2\}"; then
+          VER=${{ github.event.inputs.riot_version }}
+        else
+          VER=$(git -C $GITHUB_WORKSPACE/RIOT rev-parse --short HEAD)
+        fi
+        mkdir test-reports/
+        junit2html $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
+          test-reports/test-report-native-$VER-$DATE.html
+        cp $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
+          test-reports/test-report-native-$VER-$DATE.xml
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: Upload test report
+        path: test-reports/*
+  iotlab-tasks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - name: Setup IoT-LAB credentials
+      run: |
+        echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
+    - name: Generate .riotgithubtoken
+      run: |
+        echo '${{ secrets.ACCESS_TOKEN }}' > ~/.riotgithubtoken
+    - name: Setup SSH agent
+      uses: webfactory/ssh-agent@v0.4.0
+      with:
+        ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
+    - name: Fetch host key from IoT-LAB saclay site
+      run: |
+        IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
+        ssh -oStrictHostKeyChecking=accept-new \
+          ${IOTLAB_USER}@saclay.iot-lab.info exit
+    - name: Checkout Release-Specs
+      uses: actions/checkout@v2
+      with:
+        path: Release-Specs
+    - name: Checkout RIOT
+      uses: actions/checkout@v2
+      with:
+        repository: RIOT-OS/RIOT
+        path: RIOT
+        fetch-depth: 1
+        ref: ${{ github.event.inputs.riot_version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions junit2html
+    - name: Pull riotbuild docker image
+      run: |
+        DOCKER_VERSION="${{ github.event.inputs.docker_version }}"
+        if [ -z "$DOCKER_VERSION" ]; then
+          DOCKER_VERSION="latest"
+        fi
+        docker pull riot/riotbuild:$DOCKER_VERSION
+    - name: Run release tests
+      timeout-minutes: 350
+      run: |
+        # definition in env does not work since $GITHUB_WORKSPACE seems not to
+        # be accessible
+        export RIOTBASE="$GITHUB_WORKSPACE/RIOT"
+        TOX_ARGS=""
+        if ! echo ${{ github.event.inputs.riot_version }} | \
+              grep -q "[0-9]\{4\}.[0-9]\{2\}-RC[0-9]\+"; then
+          TOX_ARGS+="--non-RC "
+        fi
+        CORES=$(cat /proc/cpuinfo | grep 'processor\s*:\s*[0-9]\+' | wc -l)
+        export DOCKER_MAKE_ARGS="-j${CORES}"
+
+        cd Release-Specs
+        BUILD_IN_DOCKER=1 \
+          DOCKER_ENV_VARS=USEMODULE \
+          $(which tox) -- ${TOX_ARGS} -m "iotlab_creds"
+    - name: junit2html and XML deploy
+      if: ${{ always() }}
+      run: |
+        DATE=$(date +"%Y-%m-%d-%H-%M-%S")
+        if echo ${{ github.event.inputs.riot_version }} | \
+              grep -q "[0-9]\{4\}.[0-9]\{2\}"; then
+          VER=${{ github.event.inputs.riot_version }}
+        else
+          VER=$(git -C $GITHUB_WORKSPACE/RIOT rev-parse --short HEAD)
+        fi
+        mkdir test-reports/
+        junit2html $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
+          test-reports/test-report-iotlab-$VER-$DATE.html
+        cp $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
+          test-reports/test-report-iotlab-$VER-$DATE.xml
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: Upload test report
+        path: test-reports/*

--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -1,6 +1,5 @@
 import time
 
-import pexpect
 import pytest
 
 from riotctrl_shell.gnrc import GNRCICMPv6Echo, GNRCPktbufStats
@@ -110,19 +109,16 @@ def test_task04(riot_ctrl):
     pinger_netif, _ = lladdr(pinger.ifconfig_list())
     pinger.ifconfig_set(pinger_netif, "channel", 26)
 
+    # enforce reconnect to pinged's terminal as connection to it in the IoT-LAB
+    # sometimes get's lost silently in the CI after the 15 min of pinging
+    pinged.stop_term()
     res = ping6(pinger, pinged_addr,
                 count=10000, interval=100, packet_size=100)
     assert res['stats']['packet_loss'] < 10
 
+    pinged.start_term()
+    assert pktbuf(pinged).is_empty()
     assert pktbuf(pinger).is_empty()
-    try:
-        assert pktbuf(pinged).is_empty()
-    except pexpect.TIMEOUT:
-        pytest.xfail(
-            "pktbuf of pinged node is not submitted reliably on the CI for "
-            "some reason. "
-            "See https://github.com/RIOT-OS/Release-Specs/pull/181"
-            "#issuecomment-667517820")
 
 
 @pytest.mark.local_only


### PR DESCRIPTION
This provides a Github Actions Workflow to run the release tests both weekly [currently configured for Sat 3:00](https://github.com/miri64/Release-Specs/blob/196e831162d222921178e7c9239ff751756d2bec/.github/workflows/release-test.yml#L4-L5) and on [triggered events](https://github.com/miri64/Release-Specs/blob/196e831162d222921178e7c9239ff751756d2bec/.github/workflows/release-test.yml#L6-L15). For the triggered runs one can either use the [REST API hook](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event) or, once this PR is merged into master, via the ["Run workflow" mask in the Actions tab](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow).

As input parameters the `riot_version` and the `docker_version` (for the `riotbuild` image) can be chosen. `riot_version` can be any git reference in the `RIOT-OS/RIOT` repo, including commit SHA1s, branches or tags. If `riot_version` is a release candidate tag (so name format like `2020.07-RC2`), the framework will recognize this and will also manipulate the test tracking issue for that RC (see #173). The idea is, that once this PR gets merged a [webhook](https://docs.github.com/en/developers/webhooks-and-events/webhooks) the workflow is run once that tag is created in `RIOT-OS/RIOT`.

For the weekly cron job, the release tests are always run against the current master of `RIOT-OS/RIOT`.

The current deployment can be checked [here](https://github.com/miri64/Release-Specs/actions?query=workflow%3A%22Release+tests%22).

# Dependencies
This PR includes ~~#164 (and all its dependencies)~~, ~~#173~~, and ~~#178~~.