### PR TITLE
tox: activate flake8 and pylint on default runs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,5 @@ disable=
   logging-format-interpolation,
   missing-module-docstring,
   missing-class-docstring,
-  missing-function-docstring
+  missing-function-docstring,
+  not-callable  # with pytest 6 `pytest.mark`s are not seen as callable

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 
 [testenv:pylint]
 deps = -rrequirements.txt
+  pylint
 setenv =
   PYTHONPATH = {env:RIOTBASE}/dist/pythonlibs:{env:PYTHONPATH:}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = test
+envlist = test,flake8,pylint
 skipsdist = True
 
 [gh-actions]
 python =
-    3.8: py38,flake8,test
+    3.8: py38,flake8,pylint,test
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
This takes out the remaining commit in #164, so that `pylint` and `flake8` are always executed on all tests.

For testing, just look at the output of the github action in the status of this PR. `pylint` and `flake8` should now be executed