### PR TITLE
09-coap/task01: fix typo

### DIFF
--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -97,7 +97,7 @@ def test_task01(riot_ctrl, log_nodes):
         if core_reg["ltime"] > 300:
             pytest.xfail("CoRE RD lifetime is configured for {}s (> 5min). "
                          "That's way to long for a test!"
-                         .format(core_reg["ltiem"]))
+                         .format(core_reg["ltime"]))
         time.sleep(core_reg["ltime"])
     finally:
         aiocoap_rd.terminate()


### PR DESCRIPTION
I found a typo in task 9.1 while reviewing and testing #190. This never made any problems so far, since the `examples/cord_ep` application is configured as expected and more of a fail-safe than anything else.