### PR TITLE
10-icmpv6-error: fix task07 for RIOT-OS/RIOT#15430

### DIFF
--- a/10-icmpv6-error/README.md
+++ b/10-icmpv6-error/README.md
@@ -219,9 +219,10 @@ hop link but not the second hop link via a native node from a Linux host.
         # ip route add affe::/64 via "<native link local IPv6 address>" \
                 dev tapbr0
 
-3. Compile `gnrc_networking` for `native` with `socket_zep` module
+3. Compile `gnrc_networking` for `native` with both `socket_zep` and
+   `netdev_tap` module
 
-        $ GNRC_NETIF_NUMOF=2 USEMODULE=socket_zep \
+        $ GNRC_NETIF_NUMOF=2 USEMODULE="socket_zep netdev_tap" \
           CFLAGS=-DGNRC_IPV6_NIB_CONF_SLAAC=1 TERMFLAGS="-z [::]:17755 tap0" \
             make -C examples/gnrc_networking clean all term
 

--- a/10-icmpv6-error/test_spec10.py
+++ b/10-icmpv6-error/test_spec10.py
@@ -223,7 +223,8 @@ def test_task07(riot_ctrl, log_nodes):
     node = riot_ctrl(0, APP, Shell,
                      cflags="-DCONFIG_GNRC_IPV6_NIB_SLAAC=1 "
                             "-DCONFIG_GNRC_IPV6_NIB_QUEUE_PKT=1",
-                     termflags="-z [::]:17755", modules="socket_zep",
+                     termflags="-z [::]:17755",
+                     modules="socket_zep netdev_tap",
                      port=TAP)
     host_netif = bridge(TAP)
     host_lladdr = get_link_local(host_netif)


### PR DESCRIPTION
With https://github.com/RIOT-OS/RIOT/pull/15430 in current master of RIOT, both `socket_zep` and `native_tap` needs to be added to `USEMODULE` if both devices want to be used. Otherwise, [only one of both will be selected](https://github.com/RIOT-OS/RIOT/runs/1502334614?check_suite_focus=true#step:9:72). This PR updates the doc and the test of task 10.7 to reflect that change.

To test, just run

```sh
sudo RIOTBASE=$(readlink -f <riotpath>) tox -- -k "spec10 and task07" --non-RC
```

with `<riotpath>` having a current version of RIOT master checked out. Without this PR, the test will fail, with it, it will succeed.