### PR TITLE
04-single-hop: increase radio HAL coverage

### DIFF
--- a/04-single-hop-6lowpan-icmp/README.md
+++ b/04-single-hop-6lowpan-icmp/README.md
@@ -65,12 +65,12 @@ ICMPv6 echo request/reply exchange between an iotlab-m3 and a samr21-xpro node.
 
 <10% packets lost on the pinging node.
 
-Task #05 (Experimental) - ICMPv6 multicast echo with samr21-xpro/remote
+Task #05 (Experimental) - ICMPv6 multicast echo with samr21-xpro/cc2538
 =======================================================================
 ### Description
 
-ICMPv6 echo request/reply exchange between  a Zolertia Remote node (CC2538) and
-a samr21-xpro node.
+ICMPv6 echo request/reply exchange between a CC2538 (e.g Zolertia Remote,
+Firefly) and a samr21-xpro node.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                17
 * Count:                  1000
@@ -82,12 +82,12 @@ a samr21-xpro node.
 
 <10% packets lost on the pinging node.
 
-Task #06 (Experimental) - ICMPv6 link-local echo with samr21-xpro/remote
-========================================================================
+Task #06 (Experimental)- ICMPv6 link-local echo with samr21-xpro/cc2538
+=======================================================================
 ### Description
 
-ICMPv6 echo request/reply exchange between a Zolertia Remote node (CC2538) and
-a samr21-xpro node.
+ICMPv6 echo request/reply exchange between a CC2538 (e.g Zolertia Remote,
+Firefly) and a samr21-xpro node.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                26
 * Count:                  1000

--- a/04-single-hop-6lowpan-icmp/README.md
+++ b/04-single-hop-6lowpan-icmp/README.md
@@ -152,8 +152,8 @@ All nodes are still running, reachable, and the packet buffer is empty 3 seconds
 after completions (use module `gnrc_pktbuf_cmd`).
 Packet loss is irrelevant in this stress test.
 
-Task #10 (Exprimental) - ICMPv6 echo with large payload (IPv6 fragmentation)
-============================================================================
+Task #10 (Experimental) - ICMPv6 echo with large payload (IPv6 fragmentation)
+=============================================================================
 ### Description
 
 ICMPv6 echo request/reply exchange between two nodes (make sure module

--- a/04-single-hop-6lowpan-icmp/README.md
+++ b/04-single-hop-6lowpan-icmp/README.md
@@ -170,3 +170,57 @@ both the fragmented and reassembled requests/replies).
 
 <10% packets lost on the pinging node.
 No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+
+Task #11 (Experimental) - ICMPv6 stress test on nrf802154
+=========================================================
+### Description
+
+Rapid ICMPv6 echo request/reply exchange between an a nrf802154 based node
+(pinged) and 2 iotlab-m3 nodes (pinging) simultaneously.
+
+* Stack configuration:    6LoWPAN (default)
+* Channel:                26
+* Count:                  200
+* Interval:               0ms
+* Payload:                1232B
+* Destination Address:    Link local unicast (fe80::.../64)
+
+### Result
+
+All nodes are still running, reachable, and the packet buffer is empty 3 seconds
+after completions (use module `gnrc_pktbuf_cmd`).
+Packet loss is irrelevant in this stress test.
+
+Task #12 (Experimental) - ICMPv6 multicast echo with iotlab-m3/nrf802154
+========================================================================
+### Description
+
+ICMPv6 echo request/reply exchange between a nrf802154 based node and a iotlab-m3 node.
+
+* Stack configuration:    6LoWPAN (default)
+* Channel:                17
+* Count:                  1000
+* Interval:               100ms
+* Payload:                50B
+* Destination Address:    ff02::1
+
+### Result
+
+<10% packets lost on the pinging node.
+
+Task #13 (Experimental) - ICMPv6 link-local echo with iotlab-m3/nrf802154
+=========================================================================
+### Description
+
+ICMPv6 echo request/reply exchange between a nrf802154 based node and a iotlab-m3 node.
+
+* Stack configuration:    6LoWPAN (default)
+* Channel:                26
+* Count:                  1000
+* Interval:               100ms
+* Payload:                100B
+* Destination Address:    Link local unicast (fe80::.../64)
+
+### Result
+
+<10% packets lost on the pinging node.

--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -123,16 +123,23 @@ def test_task04(riot_ctrl):
     assert pktbuf(pinger).is_empty()
 
 
-@pytest.mark.local_only
-# nodes passed to riot_ctrl fixture
-@pytest.mark.parametrize('nodes',
-                         [pytest.param(['samr21-xpro', 'remote-revb'])],
-                         indirect=['nodes'])
+@pytest.mark.iotlab_creds
+# nodes and iotlab_site passed to riot_ctrl fixture
+@pytest.mark.parametrize('nodes, iotlab_site',
+                         [pytest.param(['samr21-xpro', 'firefly'], "lille")],
+                         indirect=['nodes', 'iotlab_site'])
 def test_task05(riot_ctrl):
-    pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-    )
+    try:
+        pinger, pinged = (
+            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        )
+    except subprocess.CalledProcessError:
+        pytest.xfail(
+            "Experimental task. See also "
+            # pylint: disable=C0301
+            "https://github.com/RIOT-OS/Release-Specs/pull/198#issuecomment-756756109"  # noqa: E501
+        )
     pinged_netif, _ = lladdr(pinged.ifconfig_list())
     pinged.ifconfig_set(pinged_netif, "channel", 17)
     pinger_netif, _ = lladdr(pinger.ifconfig_list())
@@ -146,16 +153,23 @@ def test_task05(riot_ctrl):
     assert pktbuf(pinger).is_empty()
 
 
-@pytest.mark.local_only
-# nodes passed to riot_ctrl fixture
-@pytest.mark.parametrize('nodes',
-                         [pytest.param(['samr21-xpro', 'remote-revb'])],
-                         indirect=['nodes'])
+@pytest.mark.iotlab_creds
+# nodes and iotlab_site passed to riot_ctrl fixture
+@pytest.mark.parametrize('nodes, iotlab_site',
+                         [pytest.param(['samr21-xpro', 'firefly'], "lille")],
+                         indirect=['nodes', 'iotlab_site'])
 def test_task06(riot_ctrl):
-    pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-    )
+    try:
+        pinger, pinged = (
+            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        )
+    except subprocess.CalledProcessError:
+        pytest.xfail(
+            "Experimental task. See also "
+            # pylint: disable=C0301
+            "https://github.com/RIOT-OS/Release-Specs/pull/198#issuecomment-758522278"  # noqa: E501
+        )
     pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
     pinged.ifconfig_set(pinged_netif, "channel", 26)
     assert pinged_addr.startswith("fe80::")

--- a/conftest.py
+++ b/conftest.py
@@ -176,6 +176,18 @@ def boards(request):
     return request.config.getoption("--boards")
 
 
+@pytest.fixture
+def iotlab_site(request):
+    """
+    IoT-LAB site where the nodes are reserved.
+    If not specified by a test, it's fetched from the IOTLAB_SITE environment
+    variable or falls back to DEFAULT_SITE.
+    """
+
+    return getattr(request, "param",
+                   os.environ.get("IOTLAB_SITE", DEFAULT_SITE))
+
+
 def get_namefmt(request):
     name_fmt = {}
     if request.module:
@@ -187,7 +199,7 @@ def get_namefmt(request):
 
 
 @pytest.fixture
-def nodes(local, request, boards):
+def nodes(local, request, boards, iotlab_site):
     """
     Provides the nodes for a test as a list of RIOTCtrl objects
     """
@@ -212,7 +224,7 @@ def nodes(local, request, boards):
         exp = IoTLABExperiment(
             name="RIOT-release-test-{module}-{function}".format(**name_fmt),
             ctrls=ctrls,
-            site=os.environ.get("IOTLAB_SITE", DEFAULT_SITE))
+            site=iotlab_site)
         RUNNING_EXPERIMENTS.append(exp)
         exp.start(duration=IOTLAB_EXPERIMENT_DURATION)
         yield ctrls


### PR DESCRIPTION
## Contribution Description

~This PR removes the experimental tag of tasks 05 and 06 (between samr21-xpro and remote-revb), since the remote-revb compiles by default to the Radio HAL variant. Therefore it should be covered.~

This PR:
- Adds duplicates of tasks 05, 06 and 09 to be ran with the nrf52840dk. This is required since the `nrf52840dk` uses by default `netdev_ieee802154_submac`, which runs the IEEE 802.15.4 Radio HAL implementation.
- Removes the experimental tag of tasks 05 and 06 (between samr21-xpro and remote-revb), since the remote-revb compiles by default to the Radio HAL variant. Therefore it should be covered. I also expanded the test to other CC2538 radios (e.g Firefly), since they are available on IoT-LAB
- Adds a fixture for configuring the IoT-LAB site on a per-tasks basis.

I also updated the python script to include these test.

## Testing Procedure

```
RIOTBASE=<RIOTBASE> tox -- -k "spec04 and (task11 or task12 or task13)" --non-RC
```