### PR TITLE
gh-actions: don't use tox-gh-actions plugin

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - name: Checkout Release-Specs

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -36,14 +36,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox
     - name: Test with tox
       run: |
         # definition in env does not work since $GITHUB_WORKSPACE seems not to
         # be accessible
         export RIOTBASE="$GITHUB_WORKSPACE/RIOT"
+        pyenv="py$(echo "${{ matrix.python-version }}" | tr -d .)"
         cd Release-Specs
-        tox -- --doctest-modules --self-test \
+        tox -e "test,${pyenv},flake8,pylint" -- --doctest-modules --self-test \
             --cov=testutils --cov-report term-missing \
             --cov-config=testutils/.coveragerc \
             --cov-fail-under=95

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -38,10 +38,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox
     - name: Test with tox
+      env:
+        RIOTBASE: ${{ github.workspace }}/RIOT
       run: |
-        # definition in env does not work since $GITHUB_WORKSPACE seems not to
-        # be accessible
-        export RIOTBASE="$GITHUB_WORKSPACE/RIOT"
         pyenv="py$(echo "${{ matrix.python-version }}" | tr -d .)"
         cd Release-Specs
         tox -e "test,${pyenv},flake8,pylint" -- --doctest-modules --self-test \


### PR DESCRIPTION
@aabadie warned me to use that plugin, and now it shows... for some reason it does not execute neither flake8 nor pylint. This removes the usage of the `tex-gh-actions` plugin and also adds `3.9` tests.