### PR TITLE
04-single-hop-6lowpan-icmp: add missing iotlab_creds

### DIFF
--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -348,6 +348,7 @@ def test_task11(riot_ctrl):
         assert pktbuf(node).is_empty()
 
 
+@pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
                          [pytest.param(['iotlab-m3', 'nrf52840dk'])],
@@ -377,6 +378,7 @@ def test_task12(riot_ctrl):
     assert pktbuf(pinger).is_empty()
 
 
+@pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
                          [pytest.param(['iotlab-m3', 'nrf52840dk'])],


### PR DESCRIPTION
This PR adds some missing `@iotlab_creds` decorators to tasks 12 and 13. Without these, the release-tests won't pick them.