### PR TITLE
README.md: fix link to REPLACED.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ applications if needed), that enable to execute it's tasks to the highest degree
 of automation possible. The long-term goal is the complete automated execution
 of all tasks, though there might be some cases where this is not achievable...
 
+[REPLACED.md]: ./REPLACED.md
+
 Tracking
 --------
 


### PR DESCRIPTION
The link to `REPLACED.md` introduced in https://github.com/RIOT-OS/Release-Specs/pull/157 is not a link, as the reference documentation is missing. This adds it ;-)