### PR TITLE
task7: update example_test_guide

### DIFF
--- a/07-multi-hop/example_test_guide.md
+++ b/07-multi-hop/example_test_guide.md
@@ -7,19 +7,20 @@ node1 <-> node2 <-> node3 <-> node4_
 1. Book 4 [iotlab](https://www.iot-lab.info/testbed/dashboard) M3 nodes
 
 # Task 1 and 2 Setup
+1. First build the firmware for all the nodes
+`USEMODULE=gnrc_pktbuf_cmd make -C tests/gnrc_udp/ BOARD=iotlab-m3 clean all`
 1. Open 4 instances of nodes physically close together
-`USEMODULE=gnrc_pktbuf_cmd make -C tests/gnrc_udp/ BOARD=iotlab-m3
-IOTLAB_NODE=<iotlab id> flash term`
-2. On each end of the nodes add a global IP address (ie. node1:`ifconfig 6 add
-    abcd::1` and node 4: `ifconfig 6 add abcd::2`)
-3. Add the routing for both ways:
-- Node 1: `nib route add 6 abcd::2 <ipv6 addr of node 2>`
-- Node 2: `nib route add 6 abcd::2 <ipv6 addr of node 3>` and `nib route add 6
-abcd::1 <ipv6 addr of node 1>`
-- Node 3: `nib route add 6 abcd::2 <ipv6 addr of node 4>` and `nib route add 6
-abcd::1 <ipv6 addr of node 2>`
-- Node 4: `nib route add 6 abcd::1 <ipv6 addr of node 3>`
-3. Proceed to Task specific commands
+`make -C tests/gnrc_udp/ BOARD=iotlab-m3 IOTLAB_NODE=<iotlab id> flash-only term`
+1. On each end of the nodes add a global IP address (ie. node1:
+   `ifconfig 5 add abcd::1` and node 4: `ifconfig 5 add abcd::2`)
+1. Add the routing for both ways:
+    - Node 1: `nib route add 5 abcd::2 <ipv6 addr of node 2>`
+    - Node 2: `nib route add 5 abcd::2 <ipv6 addr of node 3>` and
+              `nib route add 5 abcd::1 <ipv6 addr of node 1>`
+    - Node 3: `nib route add 5 abcd::2 <ipv6 addr of node 4>` and
+              `nib route add 5 abcd::1 <ipv6 addr of node 2>`
+    - Node 4: `nib route add 5 abcd::1 <ipv6 addr of node 3>`
+1. Proceed to Task specific commands
 
 
 Task #01 - ICMPv6 echo on iotlab-m3 with three hops (static route)
@@ -35,7 +36,7 @@ with static routes.
 ### Result
 
 <20% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `pktbuf`).
 
 Task #02 - UDP on iotlab-m3 with three hops (static route)
 ==========================================================
@@ -52,20 +53,25 @@ Sending UDP between two iotlab-m3 nodes over three hops with static routes.
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `pktbuf`).
 
 
 # Task 3 and 4 Setup
+1. First build the firmware for all the nodes
+`USEMODULE="l2filter_whitelist gnrc_pktbuf_cmd" BOARD=iotlab-m3 make -C tests/gnrc_udp/ clean all`
 1. Flash all nodes with with the l2filter_whitelist module firmware
-`USEMODULE="l2filter_whitelist gnrc_pktbuf_cmd" BOARD=iotlab-m3 IOTLAB_NODE=<iotlab id> make -C tests/gnrc_udp/ flash term`
-2. Setup the l2filter_whitelist addresses
-- Node 1: `ifconfig 6 l2filter add <MAC addr of node 2>`
-- Node 2: `ifconfig 6 l2filter add <MAC addr of node 1>` and `ifconfig 6 l2filter add <MAC addr of node 3>`
-- Node 3: `ifconfig 6 l2filter add <MAC addr of node 2>` and `ifconfig 6 l2filter add <MAC addr of node 4>`
-- Node 4: `ifconfig 6 l2filter add <MAC addr of node 3>`
-3. Add a global IP address, Node 1: `ifconfig 6 add abcd::1/64`
-4. Apply rpl root, Node 1: `rpl root 0 abcd::1`
-5. Check Node 4 for R >= 1024 indicating more at least 3 hops,  Node 4:
+`BOARD=iotlab-m3 IOTLAB_NODE=<iotlab id> make -C tests/gnrc_udp/ flash-only term`
+1. Setup the l2filter_whitelist addresses
+    - Node 1: `ifconfig 5 l2filter add <MAC addr of node 2>`
+    - Node 2: `ifconfig 5 l2filter add <MAC addr of node 1>` and
+              `ifconfig 5 l2filter add <MAC addr of node 3>`
+    - Node 3: `ifconfig 5 l2filter add <MAC addr of node 2>` and
+              `ifconfig 5 l2filter add <MAC addr of node 4>`
+    - Node 4: `ifconfig 5 l2filter add <MAC addr of node 3>`
+    - Node all: `rpl init 5`
+1. Add a global IP address, Node 1: `ifconfig 5 add abcd::1/64`
+1. Apply rpl root, Node 1: `rpl root 0 abcd::1`
+1. Check Node 4 for R >= 1024 indicating more at least 3 hops,  Node 4:
 
 ```
 > rpl
@@ -73,7 +79,7 @@ rpl
 instance table: [X]
 parent table:   [X]     [ ]     [ ]
 
-instance [0 | Iface: 6 | mop: 2 | ocp: 0 | mhri: 256 | mri 0]
+instance [0 | Iface: 5 | mop: 2 | ocp: 0 | mhri: 256 | mri 0]
         dodag [abca::1 | R: 1024 | OP: Router | PIO: on | TR(I=[8,20], k=10, c=1, TC=14s)]
                 parent [addr: fe80::1711:6b10:65fa:5c0a | rank: 768]
 ```
@@ -86,12 +92,12 @@ ICMPv6 echo request/reply exchange between two iotlab-m3 nodes over three hops
 with RPL generated routes.
 
 1. Follow Task 3 and 4 setup
-2. Ping root node from other node, Node 4:`ping6 -c 100 -s 50 -i 100 abcd::1`
+1. Ping root node from other node, Node 4:`ping6 -c 100 -s 50 -i 100 abcd::1`
 
 ### Result
 
 <20% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `pktbuf`).
 
 Task #04 - UDP on iotlab-m3 with three hops (RPL route)
 =======================================================
@@ -100,15 +106,15 @@ Task #04 - UDP on iotlab-m3 with three hops (RPL route)
 Sending UDP between two iotlab-m3 nodes over three hops with RPL generated routes.
 
 1. Follow Task 3 and 4 setup
-2. Start a udp server on root node, Node 1:`udp server start 1234`
-3. Start a udp server on the other node, Node 4:`udp server start 4321`
-4. Send 100 packets to the other node from the root node, Node 1:`udp send abcd::<other node global address> 4321 50 100 100000`
-5. Send 100 packets to the other node from the root node, Node 4:`udp send abcd::1 1234 50 100 100000`
+1. Start a udp server on root node, Node 1:`udp server start 1234`
+1. Start a udp server on the other node, Node 4:`udp server start 4321`
+1. Send 100 packets to the other node from the root node, Node 1:`udp send abcd::<other node global address> 4321 50 100 100000`
+1. Send 100 packets to the other node from the root node, Node 4:`udp send abcd::1 1234 50 100 100000`
 
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `pktbuf`).
 
 Task #05 (Experimental) - UDP with large payload on iotlab-m3 with three hops (RPL route)
 =========================================================================================
@@ -117,12 +123,15 @@ Task #05 (Experimental) - UDP with large payload on iotlab-m3 with three hops (R
 Sending UDP between two iotlab-m3 nodes over three hops with RPL generated routes.
 
 1. Follow Task 3 and 4 setup
-2. Start a udp server on root node, Node 1:`udp server start 1234`
-3. Start a udp server on the other node, Node 4:`udp server start 4321`
-4. Send 60 packets to the other node from the root node, Node 1:`udp send abcd::<other node global address> 4321 2048 60 1000000`
-5. Send 60 packets to the other node from the root node, Node 4:`udp send abcd::1 1234 2048 60 1000000`
+1. Start a udp server on root node, Node 1:`udp server start 1234`
+1. Start a udp server on the other node, Node 4:`udp server start 4321`
+1. Send 60 packets to the other node from the root node, Node 1:`udp send abcd::<other node global address> 4321 2048 60 1000000`
+1. Send 60 packets to the other node from the root node, Node 4:`udp send abcd::1 1234 2048 60 1000000`
 
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `pktbuf`).
+
+_currently pktbuf is OK, sending is successful, but the no packets are received._
+


### PR DESCRIPTION
# CHANGES

- The default interface is 5 now
- The packet buffer check command is `pktbuf`
- There is a separate build command from the flash and term (because concurrency issues)
- A step to initialize the `rpl` instance is added for all nodes
- The experimental has the current state of the results