### PR TITLE
testutils/shell: add check_pktbuf

### DIFF
--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -1,5 +1,4 @@
 import subprocess
-import time
 
 import pytest
 
@@ -7,7 +6,7 @@ from riotctrl_shell.gnrc import GNRCICMPv6Echo, GNRCPktbufStats
 from riotctrl_shell.netif import Ifconfig
 
 from testutils.asyncio import wait_for_futures
-from testutils.shell import ping6, pktbuf, lladdr
+from testutils.shell import ping6, lladdr, check_pktbuf
 
 
 APP = 'examples/gnrc_networking'
@@ -40,8 +39,7 @@ def test_task01(riot_ctrl):
                 count=1000, interval=20, packet_size=0)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -64,8 +62,7 @@ def test_task02(riot_ctrl):
                 count=1000, interval=100, packet_size=50)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -89,8 +86,7 @@ def test_task03(riot_ctrl):
                 count=500, interval=300, packet_size=1024)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -119,8 +115,7 @@ def test_task04(riot_ctrl):
     assert res['stats']['packet_loss'] < 10
 
     pinged.start_term()
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -149,8 +144,7 @@ def test_task05(riot_ctrl):
                 count=1000, interval=100, packet_size=50)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -180,8 +174,7 @@ def test_task06(riot_ctrl):
                 count=1000, interval=100, packet_size=100)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.local_only
@@ -204,8 +197,7 @@ def test_task07(riot_ctrl):
                 count=1000, interval=100, packet_size=50)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.local_only
@@ -229,8 +221,7 @@ def test_task08(riot_ctrl):
                 count=1000, interval=350, packet_size=100)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -264,11 +255,7 @@ def test_task09(riot_ctrl):
         futures.append(out)
     wait_for_futures(futures)
 
-    time.sleep(60)
-    for node in nodes:
-        # add print to know which node's packet buffer is not empty on error
-        print("check pktbuf on", node.riotctrl.env.get("PORT"))
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -298,9 +285,7 @@ def test_task10(riot_ctrl):
         )
     assert res['stats']['packet_loss'] < 10
 
-    time.sleep(60)
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -341,11 +326,7 @@ def test_task11(riot_ctrl):
         futures.append(out)
     wait_for_futures(futures)
 
-    time.sleep(60)
-    for node in nodes:
-        # add print to know which node's packet buffer is not empty on error
-        print("check pktbuf on", node.riotctrl.env.get("PORT"))
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -374,8 +355,7 @@ def test_task12(riot_ctrl):
                 count=1000, interval=100, packet_size=50)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -405,5 +385,4 @@ def test_task13(riot_ctrl):
                 count=1000, interval=100, packet_size=100)
     assert res['stats']['packet_loss'] < 10
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)

--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -1,12 +1,10 @@
-import time
-
 import pytest
 
 from riotctrl_shell.gnrc import GNRCICMPv6Echo, GNRCIPv6NIB, GNRCPktbufStats
 from riotctrl_shell.netif import Ifconfig
 
 from testutils.native import bridged
-from testutils.shell import ping6, pktbuf, lladdr
+from testutils.shell import ping6, lladdr, check_pktbuf
 
 
 APP = 'examples/gnrc_networking'
@@ -43,8 +41,7 @@ def test_task01(riot_ctrl):
                 count=100, interval=10, packet_size=1024)
     assert res['stats']['packet_loss'] < 1
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.iotlab_creds
@@ -69,9 +66,7 @@ def test_task02(riot_ctrl):
                 count=100, interval=300, packet_size=1024)
     assert res['stats']['packet_loss'] < 10
 
-    time.sleep(10)
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.skipif(not bridged(["tap0", "tap1"]),
@@ -99,8 +94,7 @@ def test_task03(riot_ctrl):
                 count=10, interval=10, packet_size=1024)
     assert res['stats']['packet_loss'] < 1
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)
 
 
 @pytest.mark.skipif(not bridged(["tap0", "tap1"]),
@@ -127,5 +121,4 @@ def test_task04(riot_ctrl):
                 count=10, interval=300, packet_size=1024)
     assert res['stats']['packet_loss'] < 1
 
-    assert pktbuf(pinged).is_empty()
-    assert pktbuf(pinger).is_empty()
+    check_pktbuf(pinged, pinger)

--- a/06-single-hop-udp/test_spec06.py
+++ b/06-single-hop-udp/test_spec06.py
@@ -1,12 +1,10 @@
-import time
-
 import pytest
 
 from riotctrl_shell.gnrc import GNRCPktbufStats
 from riotctrl_shell.netif import Ifconfig
 
 from testutils.native import bridged
-from testutils.shell import pktbuf, lladdr, GNRCUDP
+from testutils.shell import lladdr, GNRCUDP, check_pktbuf
 
 
 APP = 'tests/gnrc_udp'
@@ -43,9 +41,7 @@ def test_task01(riot_ctrl):
         assert packet_loss < 5
         server.udp_server_stop()
 
-    time.sleep(10)
-    assert pktbuf(nodes[0]).is_empty()
-    assert pktbuf(nodes[1]).is_empty()
+    check_pktbuf(*nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -74,9 +70,7 @@ def test_task02(riot_ctrl):
         assert packet_loss < 5
         server.udp_server_stop()
 
-    time.sleep(10)
-    assert pktbuf(nodes[0]).is_empty()
-    assert pktbuf(nodes[1]).is_empty()
+    check_pktbuf(*nodes)
 
 
 @pytest.mark.skipif(not bridged(["tap0"]),
@@ -88,9 +82,7 @@ def test_task03(riot_ctrl):
     node = riot_ctrl(0, APP, Shell, port="tap0")
     node.udp_client_send("fe80::db:b7ec", 1337, count=1000,
                          delay_ms=0, payload=8)
-    time.sleep(10)
-    assert pktbuf(node).is_empty()
-    assert pktbuf(node).is_empty()
+    check_pktbuf(node)
 
 
 @pytest.mark.iotlab_creds
@@ -101,9 +93,7 @@ def test_task04(riot_ctrl):
     node = riot_ctrl(0, APP, Shell)
     node.udp_client_send("fe80::db:b7ec", 1337, count=1000,
                          delay_ms=0, payload=8)
-    time.sleep(10)
-    assert pktbuf(node).is_empty()
-    assert pktbuf(node).is_empty()
+    check_pktbuf(node)
 
 
 @pytest.mark.skipif(not bridged(["tap0", "tap1"]),
@@ -129,8 +119,7 @@ def test_task05(riot_ctrl):
         assert packet_loss <= 10
         server.udp_server_stop()
 
-    assert pktbuf(nodes[0]).is_empty()
-    assert pktbuf(nodes[1]).is_empty()
+    check_pktbuf(*nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -158,5 +147,4 @@ def test_task06(riot_ctrl):
         assert packet_loss <= 10
         server.udp_server_stop()
 
-    assert pktbuf(nodes[0]).is_empty()
-    assert pktbuf(nodes[1]).is_empty()
+    check_pktbuf(*nodes)

--- a/07-multi-hop/test_spec07.py
+++ b/07-multi-hop/test_spec07.py
@@ -5,8 +5,8 @@ import pytest
 from riotctrl_shell.gnrc import GNRCICMPv6Echo, GNRCIPv6NIB, GNRCPktbufStats
 from riotctrl_shell.netif import Ifconfig
 
-from testutils.shell import pktbuf, lladdr, global_addr, ping6, GNRCUDP, \
-                            PARSERS
+from testutils.shell import lladdr, global_addr, ping6, GNRCUDP, \
+                            PARSERS, check_pktbuf
 
 
 APP = 'tests/gnrc_udp'
@@ -126,9 +126,7 @@ def test_task01(statically_routed_nodes):
 
     res = ping6(pinger, TO_ADDR, count=100, packet_size=50, interval=100)
     assert res["stats"]["packet_loss"] < 20
-    time.sleep(10)
-    for node in statically_routed_nodes:
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*statically_routed_nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -148,9 +146,7 @@ def test_task02(statically_routed_nodes):
         packet_loss = server.udp_server_check_output(count=100, delay_ms=100)
         assert packet_loss < 10
         server.udp_server_stop()
-    time.sleep(10)
-    for node in statically_routed_nodes:
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*statically_routed_nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -165,9 +161,7 @@ def test_task03(rpl_nodes):
     _, root_addr = global_addr(rpl_nodes[0].ifconfig_list())
     res = ping6(pinger, root_addr, count=100, packet_size=50, interval=100)
     assert res["stats"]["packet_loss"] < 20
-    time.sleep(10)
-    for node in rpl_nodes:
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*rpl_nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -187,9 +181,7 @@ def test_task04(rpl_nodes):
         packet_loss = server.udp_server_check_output(count=100, delay_ms=100)
         assert packet_loss < 10
         server.udp_server_stop()
-    time.sleep(10)
-    for node in rpl_nodes:
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*rpl_nodes)
 
 
 @pytest.mark.iotlab_creds
@@ -216,6 +208,4 @@ def test_task05(rpl_nodes):
             )
         assert packet_loss < 10
         server.udp_server_stop()
-    time.sleep(10)
-    for node in rpl_nodes:
-        assert pktbuf(node).is_empty()
+    check_pktbuf(*rpl_nodes)

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -6,6 +6,7 @@ ShellInteractionParsers
 
 import math
 import re
+import time
 
 import pexpect
 from riotctrl.shell import ShellInteraction, ShellInteractionParser
@@ -177,3 +178,10 @@ def lladdr(ifconfig_out):
 
 def global_addr(ifconfig_out):
     return first_netif_and_addr_by_scope(ifconfig_out, "global")
+
+
+def check_pktbuf(*nodes, wait=10):
+    if wait:
+        time.sleep(wait)
+    for n in nodes:
+        assert pktbuf(n).is_empty()


### PR DESCRIPTION
## Contribution description

This commit fixes some race conditions when checking that all pinged nodes
have an empty pktbuf. This PR adds an utility to wait for some seconds before probing the pktbuf status.

Without this commit some of these tests fail randomly (e.g see https://github.com/RIOT-OS/RIOT/actions/runs/537422117)
## Testing Procedure
```
RIOTBASE=<absolute_path_to_RIOT_folder> IOTLAB_SITE=grenoble tox -- --non-RC -k "spec04"
```
I'm explicitly choosing a different IoTLAB site because on 8/2/2021 all Saclay nodes are reserved.