### PR TITLE
99-compile-and-test-one-board: add link for 02-tests

### DIFF
--- a/99-compile-and-test-one-board/README.md
+++ b/99-compile-and-test-one-board/README.md
@@ -8,6 +8,8 @@ Task #01 - Run tests on different hardwares
 Can be done multiple times for different boards.
 
 Compile all applications and run tests when available on a given board.
-Run `02-tests` procedure with your test board connected.
+Run [`02-tests`][02-tests] procedure with your test board connected.
 
 Please make the result files available to the release manager.
+
+[02-tests]: ../02-tests


### PR DESCRIPTION
We have the technology, so let's link the spec `99-compile-and-test-one-board` is referring to.