### PR TITLE
task8.4: fix address parsing for RIOT-OS/RIOT#15992

### DIFF
--- a/08-interop/test_spec08.py
+++ b/08-interop/test_spec08.py
@@ -66,7 +66,7 @@ def test_task08(riot_ctrl):
     _, gnrc_addr = lladdr(gnrc_node.ifconfig_list())
     assert gnrc_addr.startswith("fe80::")
     res = lwip_node.cmd("ifconfig")
-    m = re.search(r"inet6\s+(?P<addr>fe80:[0-9a-f:]+)", res)
+    m = re.search(r"inet6 addr:\s+(?P<addr>fe80:[0-9a-f:]+)", res)
     assert m is not None
     lwip_addr = m.group("addr")
 


### PR DESCRIPTION
Due to RIOT-OS/RIOT#15992 the parsing in [the release tests](https://github.com/RIOT-OS/RIOT/runs/1993539557) currently fails. Where

```sh
$ RIOTBASE=$(readlink -f ../RIOT) tox -- --non-RC -k "spec08 and task08"
```

failed before, it should succeed with this PR. (If you are facing the same problem I did that the test fails because of a `FileNotFoundError`: that's [a bug in python 3.9](https://bbs.archlinux.org/viewtopic.php?id=261816). Just delete `10-icmpv6-error/test_spec10.py` for the test (the tests in there are deselected with the command above anyways), and it will work.