### PR TITLE
tox-envfile: add support for env file

### DIFF
--- a/.devdata.env.sample
+++ b/.devdata.env.sample
@@ -1,0 +1,6 @@
+# Use this file as a template for .devdata.env
+
+### General
+
+# Path to RIOTBASE
+# RIOTBASE=/path/to/RIOT

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test-report.xml
+.devdata.env
 
 #### joe made this: http://goel.io/joe
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,17 @@ tox -- -k spec03 -k "task01 or task05"
 
 is identical to the first example.
 
+##### Using an env file to keep persistent environment variables
+
+Most tests require a set of user specific environment variable (path to
+RIOTBASE, LoRaWAN keys, etc). In order to keep these variables persistent, a
+.devdata.env file can be place in the root directory. For that, please make
+a copy of ".devdata.env.sample" and modify accordingly:
+
+```sh
+cp .devdata.env.sample .devdata.env
+```
+
 [pytest]: https://pytest.org
 [riotctrl]: https://pypi.org/project/riotctrl/
 [IoT-LAB saclay site]: https://www.iot-lab.info/deployment/saclay/

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = test,flake8,pylint
 skipsdist = True
+requires = tox-envfile
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
## Contribution description

Some tests require an extended list of environment variables (e.g LoRaWAN tests).
This PR adds https://github.com/seanh/tox-envfile/blob/master/tox_envfile.py in order to be able to store these environment variables in an env file.

Due to limitations in the original pkg, the env file is named ".devdata.env" instead of the standard ".env". Maybe we can upstream this change at some point...

## Testing
Copy the sample environment file:
```sh
cp .devdata.env.sample .devdata.env
```

And set RIOTBASE accordingly. Simply calling "tox" shouldn't complain that RIOTBASE is missing.