### PR TITLE
11-lorawan: add RIOTCtrl tests for GNRC LoRaWAN

### DIFF
--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -84,7 +84,7 @@ def test_task01(riot_ctrl, log_nodes):
 
     node_netif, _ = lladdr(node.ifconfig_list())
     node.ifconfig_add(node_netif, NODE_ULA)
-
+    # pylint: disable=R1732
     aiocoap_rd = subprocess.Popen(
         ["aiocoap-rd"],
         stdout=None if log_nodes else subprocess.DEVNULL,

--- a/11-lorawan/test_spec11.py
+++ b/11-lorawan/test_spec11.py
@@ -1,0 +1,111 @@
+import time
+import pytest
+from riotctrl_shell.netif import Ifconfig
+from testutils.shell import GNRCLoRaWANSend, ifconfig, lorawan_netif
+
+APP = 'examples/gnrc_lorawan'
+pytestmark = pytest.mark.rc_only()
+
+APP_PAYLOAD = "This is RIOT!"
+DOWNLINK_PAYLOAD = "VGhpcyBpcyBSSU9U"
+APP_PORT = 2
+RX2_DR = 3
+LORAWAN_DUTY_CYCLE_TIME = 10
+
+
+class Shell(Ifconfig, GNRCLoRaWANSend):
+    pass
+
+
+def run_lw_test(node, ttn_client, iface, dev_id):
+    # Disable confirmable messages
+    node.ifconfig_flag(iface, "ack_req", enable=False)
+
+    # Push a downlink message to the TTN server
+    dl_data = {"payload_raw": DOWNLINK_PAYLOAD, "port": APP_PORT,
+               "confirmed": True}
+
+    ttn_client.publish_to_dev(dev_id, **dl_data)
+
+    # Send a message. The send function will return True if the downlink is
+    # receives (as expected)
+    assert node.send(iface, APP_PAYLOAD) is True
+    time.sleep(LORAWAN_DUTY_CYCLE_TIME)
+
+    assert ttn_client.pop_uplink_payload() == APP_PAYLOAD
+
+    # Enable confirmable messages
+    node.ifconfig_flag(iface, "ack_req", enable=True)
+
+    # Send a message. In this case we shouldn't receive a downlink.
+    assert node.send(iface, APP_PAYLOAD) is False
+
+    assert ttn_client.pop_uplink_payload() == APP_PAYLOAD
+    assert ttn_client.downlink_ack_received()
+
+
+@pytest.mark.iotlab_creds
+# nodes passed to riot_ctrl fixture
+@pytest.mark.parametrize('nodes,dev_id',
+                         [pytest.param(['b-l072z-lrwan1'], "otaa")],
+                         indirect=['nodes', 'dev_id'])
+# pylint: disable=R0913
+def test_task05(riot_ctrl, ttn_client, dev_id, deveui,
+                appeui, appkey):
+    node = riot_ctrl(0, APP, Shell)
+
+    iface = lorawan_netif(node)
+    assert iface
+
+    # Set the OTAA keys
+    node.ifconfig_set(iface, "deveui", deveui)
+    node.ifconfig_set(iface, "appeui", appeui)
+    node.ifconfig_set(iface, "appkey", appkey)
+
+    # Enable OTAA
+    node.ifconfig_flag(iface, "otaa", enable=True)
+
+    # Trigger Join Request
+    node.ifconfig_up(iface)
+
+    # Wait until the LoRaWAN network is joined
+    time.sleep(10)
+
+    netif = ifconfig(node, iface)
+    assert netif[str(iface)]["link"] == "up"
+
+    run_lw_test(node, ttn_client, iface, dev_id)
+
+
+@pytest.mark.iotlab_creds
+# nodes passed to riot_ctrl fixture
+@pytest.mark.parametrize('nodes,dev_id',
+                         [pytest.param(['b-l072z-lrwan1'], "abp")],
+                         indirect=['nodes', 'dev_id'])
+# pylint: disable=R0913
+def test_task06(riot_ctrl, ttn_client, dev_id,
+                devaddr, nwkskey, appskey):
+    node = riot_ctrl(0, APP, Shell)
+
+    iface = lorawan_netif(node)
+    assert iface
+
+    # Set the OTAA keys
+    node.ifconfig_set(iface, "addr", devaddr)
+    node.ifconfig_set(iface, "nwkskey", nwkskey)
+    node.ifconfig_set(iface, "appskey", appskey)
+    node.ifconfig_set(iface, "rx2_dr", RX2_DR)
+
+    # Enable OTAA
+    node.ifconfig_flag(iface, "otaa", enable=False)
+
+    # Trigger Join Request
+    node.ifconfig_up(iface)
+
+    # Wait until the LoRaWAN network is joined
+    time.sleep(10)
+
+    netif = ifconfig(node, iface)
+    assert netif[str(iface)]["link"] == "up"
+
+    run_lw_test(node, ttn_client, iface, dev_id)

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 import time
+
 from collections.abc import Iterable
 
 import pytest
@@ -19,6 +20,9 @@ from riotctrl.ctrl import RIOTCtrl
 import testutils.github
 import testutils.pytest
 from testutils.iotlab import IoTLABExperiment, DEFAULT_SITE
+
+from testutils.pytest import get_required_envvar
+from testutils import ttn
 
 
 IOTLAB_EXPERIMENT_DURATION = 120
@@ -125,6 +129,50 @@ def pytest_keyboard_interrupt(excinfo):
         child.stop_term()
     for exp in RUNNING_EXPERIMENTS:
         exp.stop()
+
+
+@pytest.fixture
+def dev_id(request):
+    if request.param == "otaa":
+        return ttn.DEVICE_ID
+
+    return ttn.DEVICE_ID_ABP
+
+
+@pytest.fixture
+def appkey():
+    return get_required_envvar("APPKEY")
+
+
+@pytest.fixture
+def appeui():
+    return ttn.APPEUI
+
+
+@pytest.fixture
+def deveui():
+    return ttn.DEVEUI
+
+
+@pytest.fixture
+def devaddr():
+    return ttn.DEVADDR
+
+
+@pytest.fixture
+def nwkskey():
+    return get_required_envvar("NWKSKEY")
+
+
+@pytest.fixture
+def appskey():
+    return get_required_envvar("APPSKEY")
+
+
+@pytest.fixture
+def ttn_client():
+    with ttn.TTNClient() as client:
+        yield client
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 riotctrl
 scapy
+paho-mqtt

--- a/testutils/pytest.py
+++ b/testutils/pytest.py
@@ -107,3 +107,13 @@ def check_rc(only_rc_allowed):
             reason="RIOT version under test is not a release candidate"
         )
     return rc_only_mark
+
+
+def get_required_envvar(envvar):
+    """
+    Returns the value of an environment variable. Raise RuntimeError otherwise.
+    """
+    try:
+        return os.environ[envvar]
+    except KeyError as err:
+        raise RuntimeError("Missing {} env variable".format(envvar)) from err

--- a/testutils/tests/test_github.py
+++ b/testutils/tests/test_github.py
@@ -64,7 +64,8 @@ def test_get_repo_error(caplog):
     class MockGithub():
         # pylint: disable=R0201,W0613
         def get_repo(self, name):
-            raise testutils.github.GithubException(404, data="I am not repo")
+            raise testutils.github.GithubException(404, "I am not repo",
+                                                   None)
 
     with caplog.at_level(logging.ERROR):
         assert not testutils.github.get_repo(MockGithub())
@@ -116,7 +117,8 @@ def test_get_rc_tracking_issue_error(caplog):
     class MockRepo():
         # pylint: disable=R0201,W0613
         def get_issues(self, *args, **kwargs):
-            raise testutils.github.GithubException(403, "You don't get issues")
+            raise testutils.github.GithubException(403, "You don't get issues",
+                                                   None)
 
     rc = {"release": "2456.13", "candidate": "RC74"}
     repo = MockRepo()
@@ -180,7 +182,7 @@ def test_mark_task_done_error1(caplog, raiser):
 
     # pylint: disable=W0613
     def _raise(*args, **kwargs):
-        raise testutils.github.GithubException(404, "This went wrong")
+        raise testutils.github.GithubException(404, "This went wrong", None)
 
     issue = MockIssue(" - [ ] foobar")
     setattr(issue, raiser, _raise)
@@ -199,7 +201,8 @@ def test_mark_task_done_error2(caplog):
 
         @property
         def body(self):
-            raise testutils.github.GithubException(404, "This went wrong")
+            raise testutils.github.GithubException(404, "This went wrong",
+                                                   None)
 
         # pylint: disable=W0613
         def edit(self, body, *args, **kwargs):
@@ -372,7 +375,7 @@ def test_make_comment_error(monkeypatch, caplog, outcome, longrepr, sections,
 
         # pylint: disable=R0201,W0613
         def create_comment(self, comment):
-            raise testutils.github.GithubException(300, "Nope")
+            raise testutils.github.GithubException(300, "Nope", None)
 
     monkeypatch.setattr(testutils.github.os, "environ", {})
     report = _get_mock_report(outcome, longrepr, sections)
@@ -511,7 +514,7 @@ def test_update_issue(monkeypatch, caplog, when, outcome, tested_task, rc,
     if task is None:
         # pylint: disable=W0613
         def _raise(*args, **kwargs):
-            raise testutils.github.GithubException(420, "Fail!")
+            raise testutils.github.GithubException(420, "Fail!", None)
         monkeypatch.setattr(testutils.github, "find_task_text", _raise)
     else:
         monkeypatch.setattr(testutils.github, "find_task_text",

--- a/testutils/tests/test_pytest.py
+++ b/testutils/tests/test_pytest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import testutils.pytest
@@ -63,3 +64,12 @@ def test_check_rc(monkeypatch, output, only_rc_allowed, expect_func):
     monkeypatch.setattr(testutils.pytest.subprocess, "check_output",
                         lambda *args, **kwargs: output)
     assert expect_func(testutils.pytest.check_rc(only_rc_allowed))
+
+
+def test_get_required_envvar():
+    os.environ['foo'] = 'bar'
+    assert testutils.pytest.get_required_envvar('foo') == 'bar'
+    del os.environ['foo']
+    with pytest.raises(RuntimeError) as error:
+        testutils.pytest.get_required_envvar('foo')
+    assert str(error.value) == "Missing foo env variable"

--- a/testutils/tests/test_shell.py
+++ b/testutils/tests/test_shell.py
@@ -10,6 +10,7 @@ import pexpect
 import pytest
 
 import riotctrl_shell.gnrc
+import riotctrl_shell.netif
 import riotctrl_shell.tests.common
 from riotctrl_shell.tests.common import init_ctrl
 
@@ -242,3 +243,85 @@ def test_check_pktbuf_empty(monkeypatch):
 
     with pytest.raises(AssertionError):
         testutils.shell.check_pktbuf(*nodes)
+
+
+def test_ifconfig():
+    ctrl = init_ctrl(output="""
+ifconfig
+Iface  3  HWaddr: 26:01:24:C0  Frequency: 869524963Hz  BW: 125kHz  SF: 12  CR: 4/5  Link: up
+           TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0
+          IQ_INVERT
+          RX_SINGLE  OTAA  L2-PDU:2559
+          """)  # noqa: E501
+    shell = riotctrl_shell.netif.Ifconfig(ctrl)
+    res = testutils.shell.ifconfig(shell)
+    assert len(res) == 1
+    assert '3' in res
+
+
+def test_lorawan_netif_None():
+    ctrl = init_ctrl(output="""
+ifconfig
+Iface  7  HWaddr: 76:F5:98:9F:40:22
+          L2-PDU:1500  MTU:1500  HL:64  RTR
+          Source address length: 6
+          Link type: wired
+          inet6 addr: fe80::74f5:98ff:fe9f:4022  scope: link  VAL
+          inet6 addr: fe80::2  scope: link  VAL
+          inet6 group: ff02::2
+          inet6 group: ff02::1
+          inet6 group: ff02::1:ff9f:4022
+          inet6 group: ff02::1:ff00:2
+          """)
+    shell = riotctrl_shell.netif.Ifconfig(ctrl)
+    res = testutils.shell.lorawan_netif(shell)
+    assert res is None
+
+
+def test_lorawan_netif_no_lorawan():
+    ctrl = init_ctrl(output="""
+ifconfig
+Iface  3  HWaddr: 26:01:24:C0  Frequency: 869524963Hz  BW: 125kHz  SF: 12  CR: 4/5  Link: up
+           TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0
+          IQ_INVERT
+          RX_SINGLE  OTAA  L2-PDU:2559
+          """)  # noqa: E501
+    shell = riotctrl_shell.netif.Ifconfig(ctrl)
+    res = testutils.shell.lorawan_netif(shell)
+    assert res == 3
+
+
+def test_gnrc_lorawan_send_success():
+    ctrl = init_ctrl(output="""
+send 3 "Hello RIOT!" 2
+Successfully sent packet
+""")
+    shell = testutils.shell.GNRCLoRaWANSend(ctrl)
+    res = shell.send(3, "Hello RIOT!")
+    assert res is False
+
+
+def test_gnrc_lorawan_send_success_downlink():
+    ctrl = init_ctrl(output="""
+send 3 "Hello RIOT!" 2
+PKTDUMP: data received:
+~~ SNIP  0 - size:   4 byte, type: NETTYPE_LORAWAN (1)
+00000000  AA  AA  AA  AA
+~~ PKT    -  1 snips, total size:   4 byte
+Successfully sent packet
+""")
+    shell = testutils.shell.GNRCLoRaWANSend(ctrl)
+    res = shell.send(3, "Hello RIOT!")
+    assert res is True
+
+
+def test_gnrc_lorawan_send_fail():
+    LORAWAN_FAIL_TO_SEND = """
+send 3 "Hello RIOT!" 4
+Error sending packet: (status: -116)
+"""
+    ctrl = init_ctrl(output=LORAWAN_FAIL_TO_SEND)
+    shell = testutils.shell.GNRCLoRaWANSend(ctrl)
+    with pytest.raises(RuntimeError) as error:
+        shell.send(3, "Hello RIOT!")
+    assert str(error.value) == LORAWAN_FAIL_TO_SEND

--- a/testutils/tests/test_ttn.py
+++ b/testutils/tests/test_ttn.py
@@ -1,0 +1,152 @@
+import json
+import pytest
+import testutils.ttn
+
+TOPIC_UPLINK = '+/devices/+/up'
+TOPIC_ACK = '+/devices/+/events/down/acks'
+TOPIC_ACTIVATION = '+/devices/+/events/activations'
+SUBSCRIBE_LIST = [TOPIC_UPLINK, TOPIC_ACTIVATION, TOPIC_ACK]
+
+BASE64_PAYLOAD = '\x01\x02\x03\x04'
+TEST_DEV_ID = "0102030405060708"
+
+JSON_UPLINK = """{
+  "app_id": "my-app-id",
+  "dev_id": "my-dev-id",
+  "hardware_serial": "0102030405060708",
+  "port": 1,
+  "counter": 2,
+  "is_retry": false,
+  "confirmed": false,
+  "payload_raw": "AQIDBA==",
+  "payload_fields": {},
+  "metadata": {
+    "airtime": 46336000,
+    "time": "1970-01-01T00:00:00Z",
+    "frequency": 868.1,
+    "modulation": "LORA",
+    "data_rate": "SF7BW125",
+    "bit_rate": 50000,
+    "coding_rate": "4/5",
+    "gateways": [
+      {
+        "gtw_id": "ttn-herengracht-ams",
+        "timestamp": 12345,
+        "time": "1970-01-01T00:00:00Z",
+        "channel": 0,
+        "rssi": -25,
+        "snr": 5,
+        "rf_chain": 0,
+        "latitude": 52.1234,
+        "longitude": 6.1234,
+        "altitude": 6
+      }
+    ],
+    "latitude": 52.2345,
+    "longitude": 6.2345,
+    "altitude": 2
+  }
+}
+"""
+
+JSON_DOWNLINK = "{}"
+
+
+class MockMQTTClient:
+    def __init__(self):
+        self.on_connect = None
+        self.on_message = None
+        self.data_set = None
+        self.tls = False
+        self.subscribe_list = []
+        self.downlink_list = []
+
+    @staticmethod
+    def Client():
+        return MockMQTTClient()
+
+    def user_data_set(self, data_set):
+        self.data_set = data_set
+
+    def tls_set(self):
+        self.tls = True
+
+    def username_pw_set(self, user, password):
+        pass
+
+    def connect(self, url, port, ttl):
+        # pylint: disable=W0613
+        self.on_connect(self, self.data_set, None, None)
+
+    def loop_start(self):
+        pass
+
+    def loop_stop(self):
+        pass
+
+    def publish(self, uri, data):
+        class Downlink:
+            # pylint: disable=R0903
+            def __init__(self):
+                self.uri = uri
+                self.data = data
+
+        self.downlink_list.append(Downlink())
+
+    def subscribe(self, uri):
+        self.subscribe_list.append(uri)
+
+    def gen_server_push(self, topic, payload):
+        class Msg:
+            # pylint: disable=R0903
+            def __init__(self):
+                self.topic = topic
+                self.payload = payload
+        self.on_message(self, self.data_set, Msg())
+
+
+@pytest.fixture(autouse=True)
+def replace_mqtt(monkeypatch):
+    monkeypatch.setenv("LORAWAN_DL_KEY", "dl_key")
+    monkeypatch.setattr(testutils.ttn, "mqtt", MockMQTTClient)
+
+
+def test_on_connect(ttn_client):
+    for element in ttn_client.mqtt.subscribe_list:
+        assert element in SUBSCRIBE_LIST
+
+
+def test_on_message_data(ttn_client):
+    ttn_client.mqtt.gen_server_push(TOPIC_UPLINK, JSON_UPLINK)
+    assert len(ttn_client.mqtt.data_set.msg) == 1
+    assert not ttn_client.mqtt.data_set.ack
+
+
+def test_on_message_ack(ttn_client):
+    ttn_client.mqtt.gen_server_push(TOPIC_ACK, JSON_DOWNLINK)
+    assert len(ttn_client.mqtt.data_set.msg) == 0
+    assert ttn_client.mqtt.data_set.ack
+
+
+def test_publish_to_dev(ttn_client):
+    ttn_client.publish_to_dev(TEST_DEV_ID, foo="bar")
+    downlink = ttn_client.mqtt.downlink_list.pop()
+    expected_uri = '{}/devices/{}/down'.format(testutils.ttn.APP_ID,
+                                               TEST_DEV_ID)
+    assert downlink.uri == expected_uri
+    assert json.loads(downlink.data)["foo"] == "bar"
+
+
+def test_pop_uplink_payload(ttn_client):
+    ttn_client.mqtt.gen_server_push(TOPIC_UPLINK, JSON_UPLINK)
+    payload = ttn_client.pop_uplink_payload()
+    assert payload == BASE64_PAYLOAD
+    with pytest.raises(RuntimeError):
+        ttn_client.pop_uplink_payload()
+
+
+def test_downlink_ack_received(ttn_client):
+    assert not ttn_client.ack
+
+    ttn_client.ack = True
+    assert ttn_client.downlink_ack_received()

--- a/testutils/ttn.py
+++ b/testutils/ttn.py
@@ -1,0 +1,74 @@
+import os
+import re
+import json
+import base64
+
+import paho.mqtt.client as mqtt
+from testutils.pytest import get_required_envvar
+
+APP_ID = os.environ.get("TTN_APP_ID", "11-lorawan")
+DEVICE_ID = os.environ.get("TTN_DEV_ID", "riot_lorawan_1")
+DEVICE_ID_ABP = os.environ.get("TTN_DEV_ID_ABP", "riot_lorawan_1_abp")
+DEVEUI = os.environ.get("DEVEUI", "009E40529364FBE6")
+APPEUI = os.environ.get("APPEUI", "70B3D57ED003B26A")
+DEVADDR = os.environ.get("DEVADDR", "26011EB0")
+
+
+def on_connect(client, userdata, flags, rc):
+    # pylint: disable=W0613
+    """
+    The callback for when the client receives a CONNACK response from the
+    server.
+    """
+    client.subscribe('+/devices/+/up')
+    client.subscribe('+/devices/+/events/activations')
+    client.subscribe("+/devices/+/events/down/acks")
+
+
+def on_message(client, userdata, msg):
+    # pylint: disable=W0613
+    """
+    The callback for when a PUBLISH message is received from the server.
+    """
+    topic = msg.topic
+    data = json.loads(msg.payload)
+    if re.search("up", topic):
+        userdata.msg.append(data)
+    elif re.search("down", topic):
+        userdata.ack = True
+
+
+class TTNClient:
+    def __init__(self):
+        client = mqtt.Client()
+        client.on_connect = on_connect
+        client.on_message = on_message
+        self.mqtt = client
+        self.msg = []
+        self.ack = False
+
+    def __enter__(self):
+        self.mqtt.user_data_set(self)
+        self.mqtt.tls_set()
+        password = get_required_envvar("LORAWAN_DL_KEY")
+        self.mqtt.username_pw_set(APP_ID, password=password)
+        self.mqtt.connect('eu.thethings.network', 8883, 60)
+        self.mqtt.loop_start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.mqtt.loop_stop()
+
+    def publish_to_dev(self, dev_id, **kwargs):
+        self.mqtt.publish("{}/devices/{}/down".format(APP_ID, dev_id),
+                          json.dumps(kwargs))
+
+    def pop_uplink_payload(self):
+        try:
+            base64_payload = self.msg.pop()["payload_raw"]
+            return base64.b64decode(base64_payload).decode('ascii')
+        except IndexError as err:
+            raise RuntimeError("Uplink queue empty") from err
+
+    def downlink_ack_received(self):
+        return self.ack

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,5 @@ commands =
     07-multi-hop/ \
     08-interop/ \
     09-coap/ \
-    10-icmpv6-error/
+    10-icmpv6-error/ \
+    11-lorawan/

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,16 @@ passenv =
   RIOTBASE
   SSH_AUTH_SOCK
   SSH_AGENT_PID
+  APPKEY
+  NWKSKEY
+  APPSKEY
+  LORAWAN_DL_KEY
+  TTN_APP_ID
+  TTN_DEV_ID
+  TTN_DEV_ID_ABP
+  DEVEUI
+  APPEUI
+  DEVADDR
 setenv =
   PYTHONPATH = {env:RIOTBASE}/dist/pythonlibs:{env:PYTHONPATH:}
 deps = -rrequirements.txt


### PR DESCRIPTION
Duplicate of #201 , but this time from the right repo...

## Contribution description

This PR adds the RIOTCtrl counterpart for #199. This test is using a TTN account and MQTT in order to check uplink and downlink messages, besides activations from the Network Server.
I plan to migrate the existing semtech LoRaMAC tests as soon as possible in order to also use these mechanisms, but I gave priority to GNRC LoRaWAN because it had no autotests.

## Test procedure
Check github workflow output

## Related issues/PRs
#199 