### PR TITLE
release-tests: mark IoT-LAB runs as flaky

### DIFF
--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -18,6 +18,7 @@ class Shell(Ifconfig, GNRCICMPv6Echo, GNRCPktbufStats):
     pass
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -42,6 +43,7 @@ def test_task01(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -65,6 +67,7 @@ def test_task02(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -89,6 +92,7 @@ def test_task03(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -118,6 +122,7 @@ def test_task04(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes and iotlab_site passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes, iotlab_site',
@@ -147,6 +152,7 @@ def test_task05(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes and iotlab_site passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes, iotlab_site',
@@ -329,6 +335,7 @@ def test_task11(riot_ctrl):
     check_pktbuf(*nodes)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -358,6 +365,7 @@ def test_task12(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',

--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -44,6 +44,7 @@ def test_task01(riot_ctrl):
     check_pktbuf(pinged, pinger)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 @pytest.mark.parametrize('nodes',
                          [pytest.param(['iotlab-m3', 'iotlab-m3'])],

--- a/06-single-hop-udp/test_spec06.py
+++ b/06-single-hop-udp/test_spec06.py
@@ -15,6 +15,7 @@ class Shell(Ifconfig, GNRCPktbufStats, GNRCUDP):
     pass
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -44,6 +45,7 @@ def test_task01(riot_ctrl):
     check_pktbuf(*nodes)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -122,6 +124,7 @@ def test_task05(riot_ctrl):
     check_pktbuf(*nodes)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 @pytest.mark.parametrize('nodes',
                          [pytest.param(['iotlab-m3', 'iotlab-m3'])],

--- a/07-multi-hop/test_spec07.py
+++ b/07-multi-hop/test_spec07.py
@@ -115,6 +115,7 @@ def rpl_nodes(riot_ctrl, netif_parser):
     return nodes
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to statically_routed_nodes for riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -129,6 +130,7 @@ def test_task01(statically_routed_nodes):
     check_pktbuf(*statically_routed_nodes)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to statically_routed_nodes for riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -149,6 +151,7 @@ def test_task02(statically_routed_nodes):
     check_pktbuf(*statically_routed_nodes)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to rpl_nodes for riot_ctrl fixture
 @pytest.mark.parametrize('nodes',
@@ -164,6 +167,7 @@ def test_task03(rpl_nodes):
     check_pktbuf(*rpl_nodes)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to rpl_nodes for riot_ctrl fixture
 @pytest.mark.parametrize('nodes',

--- a/08-interop/test_spec08.py
+++ b/08-interop/test_spec08.py
@@ -52,6 +52,7 @@ def test_task01(riot_ctrl, log_nodes):
     assert res["stats"]["packet_loss"] < 1
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.iotlab_creds
 # nodes passed to riot_ctrl fixture
 @pytest.mark.parametrize('nodes',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ iotlabcli
 pygithub
 pytest
 pytest-cov
+pytest-rerunfailures
 riotctrl
 scapy
 paho-mqtt


### PR DESCRIPTION
Oftentimes tests fail only because there is currently a lot of noise in the IoT-LAB testbed due to ongoing experimentation (as it is currently the case for some of the [latest runs](https://github.com/RIOT-OS/RIOT/actions/workflows/release-test.yml). This change allows for those tests to be repeated on failure after 30 seconds up to 3 times.

Experimental tests marked with XFAIL are skipped for this as they will be marked as skipped on failure anyway and that should not be hidden.