### PR TITLE
pytest: make builds quieter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -281,6 +281,7 @@ def nodes(local, request, boards, iotlab_site):
 
 
 def update_env(node, modules=None, cflags=None, port=None, termflags=None):
+    node.env['QUIETER'] = '1'
     if not isinstance(modules, str) and \
        isinstance(modules, Iterable):
         node.env['USEMODULE'] = ' '.join(str(m) for m in modules)


### PR DESCRIPTION
Whenever scrolling through the `release-tests` log, I waste a lot of time scrolling through the build log which in most cases is not really interesting. Now that `QUIETER` was introduced in https://github.com/RIOT-OS/RIOT/pull/16513 we can use that to prevent that. If for any reason, we want to check the modules used, we still can use `make info-modules` (which would have the added benefit that it also lists pseudo-modules).