### PR TITLE
pytest: move QUIETER to RIOTCtrl intialization

### DIFF
--- a/03-single-hop-ipv6-icmp/test_spec03.py
+++ b/03-single-hop-ipv6-icmp/test_spec03.py
@@ -33,6 +33,7 @@ def test_task01(riot_ctrl):
         riot_ctrl(1, APP, Shell, port='tap1'),
     )
 
+    assert False
     res = ping6(pinger, "ff02::1", count=1000, packet_size=0, interval=10)
     assert res['stats']['packet_loss'] < 1
 

--- a/conftest.py
+++ b/conftest.py
@@ -257,11 +257,12 @@ def nodes(local, request, boards, iotlab_site):
     only_native = all(b.startswith("native") for b in boards)
     for board in boards:
         if local or only_native or IoTLABExperiment.valid_board(board):
-            env = {'BOARD': '{}'.format(board)}
+            env = {'BOARD': '{}'.format(board), 'QUIETER': '1'}
         else:
             env = {
                 'BOARD': IoTLABExperiment.board_from_iotlab_node(board),
-                'IOTLAB_NODE': '{}'.format(board)
+                'IOTLAB_NODE': '{}'.format(board),
+                'QUIETER': '1',
             }
         ctrls.append(RIOTCtrl(env=env))
     if local or only_native:
@@ -281,7 +282,6 @@ def nodes(local, request, boards, iotlab_site):
 
 
 def update_env(node, modules=None, cflags=None, port=None, termflags=None):
-    node.env['QUIETER'] = '1'
     if not isinstance(modules, str) and \
        isinstance(modules, Iterable):
         node.env['USEMODULE'] = ' '.join(str(m) for m in modules)


### PR DESCRIPTION
Not sure why it doesn't work the way I did it in #224, but putting the initialization of the environment variable where I put it did not have the desired effect. When I put it to the initialization of the `RIOTCtrl` object it works as expected. You can try locally with

```sh
RIOTBASE="<absolute path to your local RIOT repo>" tox -- --non-RC -k "spec01 and task02"
```