### PR TITLE
11-lorawan: add pktbuf check

### DIFF
--- a/11-lorawan/test_spec11.py
+++ b/11-lorawan/test_spec11.py
@@ -2,6 +2,7 @@ import time
 import pytest
 from riotctrl_shell.netif import Ifconfig
 from testutils.shell import GNRCLoRaWANSend, ifconfig, lorawan_netif
+from testutils.shell import check_pktbuf
 
 APP = 'examples/gnrc_lorawan'
 pytestmark = pytest.mark.rc_only()
@@ -42,6 +43,8 @@ def run_lw_test(node, ttn_client, iface, dev_id):
 
     assert ttn_client.pop_uplink_payload() == APP_PAYLOAD
     assert ttn_client.downlink_ack_received()
+
+    check_pktbuf(node)
 
 
 @pytest.mark.iotlab_creds


### PR DESCRIPTION
## Contribution description

This PR adds a pktbuf check at the end of each GNRC LoRaWAN test. This will help detecting issues such as https://github.com/RIOT-OS/RIOT/pull/16584

## Testing procedure
Run 11-lorawan and makes sure the tests passes or fails (on current master). It shouldn't report "ERROR".