### PR TITLE
11-lorawan: mark task06 as local only

### DIFF
--- a/11-lorawan/test_spec11.py
+++ b/11-lorawan/test_spec11.py
@@ -237,6 +237,9 @@ def test_task05(riot_ctrl, ttn_client, dev_id, deveui, appeui, appkey):
     [pytest.param(["b-l072z-lrwan1"], "abp")],
     indirect=["nodes", "dev_id"],
 )
+# Missing fopts will cause it to fail on IoT-LAB(TTN, see:
+# https://github.com/RIOT-OS/RIOT/issues/16962
+@pytest.mark.local_only
 # pylint: disable=R0913
 def test_task06(riot_ctrl, ttn_client, dev_id, devaddr, nwkskey, appskey):
     node = riot_ctrl(0, GNRC_LORAWAN_APP, ShellGnrcLoRaWAN, modules=["gnrc_pktbuf_cmd"])


### PR DESCRIPTION
Mark task06 as local only since it will work with chirpstack(some versions) but not ttn. It can be removed once https://github.com/RIOT-OS/RIOT/issues/16962 is addressed. It should keep release-tests outputs clean IMO.

I'm also pushing for this because it seems that the failing test messes with the following iterations of the LoraWAN tests (something in the TTN state for that node). I'm able to fix it by resetting the node test: e.g.: `ttn-lw-cli end-devices reset release-tests eui-70b3d57ed00463e7-otaa`, but I haven't found an mqtt interface for this. I'm not sure why this happens either, but I can't investigate this further ATM.