### PR TITLE
spec09: task03/task04: adapt for new JSON output

### DIFF
--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import json
 import re
 import math
 import os
@@ -148,8 +149,12 @@ def test_task03(riot_ctrl):
     host_netif = bridge(TAP)
 
     # can't use shell interactions here, as there is no shell
-    node.riotctrl.term.expect(r"inet6 addr:\s+(fe80::[0-9a-f:]+)")
-    node_lladdr = node.riotctrl.term.match.group(1)
+    node.riotctrl.term.expect(r'{"IPv6 addresses": \[.*\].*}')
+    node_lladdr = [
+        addr
+        for addr in json.loads(node.riotctrl.term.match.group(0))["IPv6 addresses"]
+        if addr.startswith("fe80:")
+    ][0]
 
     async def client(host, block_size):
         # create async context and wait a couple of seconds
@@ -191,8 +196,12 @@ def test_task04(riot_ctrl):
     host_netif = bridge(TAP)
 
     # can't use shell interactions here, as there is no shell
-    node.riotctrl.term.expect(r"inet6 addr:\s+(fe80::[0-9a-f:]+)")
-    node_lladdr = node.riotctrl.term.match.group(1)
+    node.riotctrl.term.expect(r'{"IPv6 addresses": \[.*\].*}')
+    node_lladdr = [
+        addr
+        for addr in json.loads(node.riotctrl.term.match.group(0))["IPv6 addresses"]
+        if addr.startswith("fe80:")
+    ][0]
 
     async def client(host, block_size):
         # create async context and wait a couple of seconds

--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -44,7 +44,7 @@ class Shell(Ifconfig, CordEp):
 class TimeResource(aiocoap.resource.Resource):
     """Handle GET for clock time."""
 
-    # pylint: disable=W0613, disable=R0201
+    # pylint: disable=W0613
     async def render_get(self, request):
         payload = datetime.datetime.now().strftime("%Y-%m-%d %H:%M").encode('ascii')
         msg = aiocoap.Message(payload=payload)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ ignore = server.py,task03.py,task04.py,task05.py
 
 [pylint.messages control]
 disable=
+  consider-using-f-string,
   duplicate-code,
   fixme,
   invalid-name,

--- a/testutils/native.py
+++ b/testutils/native.py
@@ -6,9 +6,9 @@ import re
 import subprocess
 
 
-TAP_MASTER_C = re.compile(r"^\d+:\s+(?P<tap>[^:]+):.+" r"master\s+(?P<master>\S+)?")
+TAP_MASTER_C = re.compile(r"^\d+:\s+(?P<tap>[^:]+):.+master\s+(?P<master>\S+)?")
 TAP_LINK_LOCAL_C = re.compile(
-    r"inet6\s+(?P<link_local>fe80:[0-9a-f:]+)/\d+\s+" r"scope\s+link"
+    r"inet6\s+(?P<link_local>fe80:[0-9a-f:]+)/\d+\s+scope\s+link"
 )
 
 

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -138,7 +138,7 @@ class GNRCUDP(ShellInteraction):
                 continue
             try:
                 self.riotctrl.term.expect(
-                    r"~~ SNIP  0 - size:\s+\d+ byte, type: NETTYPE_UNDEF " r"\(\d+\)"
+                    r"~~ SNIP  0 - size:\s+\d+ byte, type: NETTYPE_UNDEF \(\d+\)"
                 )
                 self.riotctrl.term.expect(
                     r"~~ SNIP  1 - size:\s+\d+ byte, type: NETTYPE_UDP \(\d+\)"
@@ -147,7 +147,7 @@ class GNRCUDP(ShellInteraction):
                     r"~~ SNIP  2 - size:\s+40 byte, type: NETTYPE_IPV6 \(\d+\)"
                 )
                 self.riotctrl.term.expect(
-                    r"~~ SNIP  3 - size:\s+\d+ byte, type: NETTYPE_NETIF " r"\(-1\)"
+                    r"~~ SNIP  3 - size:\s+\d+ byte, type: NETTYPE_NETIF \(-1\)"
                 )
                 self.riotctrl.term.expect(
                     r"~~ PKT\s+-\s+4 snips, total size:\s+\d+ byte"

--- a/testutils/tests/test_github.py
+++ b/testutils/tests/test_github.py
@@ -72,7 +72,7 @@ def test_get_github(monkeypatch, access_token, expected):
 def test_get_repo():
     # pylint: disable=R0903
     class MockGithub:
-        # pylint: disable=R0201,W0613
+        # pylint: disable=W0613
         def get_repo(self, name):
             return "I am repo"
 
@@ -82,7 +82,7 @@ def test_get_repo():
 def test_get_repo_error(caplog):
     # pylint: disable=R0903
     class MockGithub:
-        # pylint: disable=R0201,W0613
+        # pylint: disable=W0613
         def get_repo(self, name):
             raise testutils.github.GithubException(404, "I am not repo", None)
 
@@ -151,7 +151,7 @@ def test_get_rc_tracking_issue(caplog, issue_titles, rc, expected_idx):
 def test_get_rc_tracking_issue_error(caplog):
     # pylint: disable=R0903
     class MockRepo:
-        # pylint: disable=R0201,W0613
+        # pylint: disable=W0613
         def get_issues(self, *args, **kwargs):
             raise testutils.github.GithubException(403, "You don't get issues", None)
 
@@ -360,7 +360,6 @@ def _github(user_class=None):
 
     # pylint: disable=R0903
     class MockGithub:
-        # pylint: disable=R0201
         def get_user(self):
             if user_class is None:
                 return MockUser()
@@ -382,7 +381,7 @@ def _github(user_class=None):
 )
 def test_find_previous_comment(comments, exp):
     class MockIssue:  # pylint: disable=R0903
-        def get_comments(self):  # pylint: disable=R0201
+        def get_comments(self):
             return comments
 
     assert testutils.github.find_previous_comment(_github(), MockIssue()) == exp
@@ -421,7 +420,7 @@ def test_create_comment(monkeypatch, caplog):
 
 def test_create_comment_error(caplog):
     class MockIssue:  # pylint: disable=R0903
-        def create_comment(self, comment):  # pylint: disable=R0201
+        def create_comment(self, comment):
             raise testutils.github.GithubException(300, "Nope", None)
 
     with caplog.at_level(logging.ERROR):
@@ -784,7 +783,7 @@ def test_upload_result_content_error(monkeypatch, caplog, tmp_path):
 
 def test_update_comment_edit_error(monkeypatch, caplog):
     class MockCommentEditError(MockComment):
-        def edit(self, body):  # pylint: disable=R0201
+        def edit(self, body):
             raise testutils.github.GithubException(300, "Nope", None)
 
     # isolate test environment
@@ -822,7 +821,7 @@ def test_get_results_gist(  # noqa: C901
     error_get,
     error_create,
 ):
-    # pylint: disable=too-few-public-methods,no-self-use,too-many-arguments
+    # pylint: disable=too-few-public-methods,too-many-arguments
     # pylint: disable=unused-argument
     class MockGist:
         def __init__(self, identifier):
@@ -1180,7 +1179,7 @@ def test_make_comment_error(
         def __init__(self):
             self.comment = None
 
-        # pylint: disable=R0201,W0613
+        # pylint: disable=W0613
         def create_comment(self, comment):
             raise testutils.github.GithubException(300, "Nope", None)
 


### PR DESCRIPTION
The address output of `examples/nanocoap_server` was changed to JSON in https://github.com/RIOT-OS/RIOT/pull/18161. This changes the parsing to account for that.

#### Testing

Run

```sh
sudo dist/tools/tapsetup/tapsetup
RIOTBASE=$(readlink -f ../RIOT) tox -e test -- -k "spec09 and (task03 or task04)" --non-RC
```

with current RIOT master checked out at `../RIOT`.
