### PR TITLE
tree-wide: s/gnrc_pktbuf_cmd/shell_cmd_gnrc_pktbuf/

### DIFF
--- a/03-single-hop-ipv6-icmp/README.md
+++ b/03-single-hop-ipv6-icmp/README.md
@@ -60,7 +60,7 @@ host, e.g. Linux host) simultaneously to one native node for 1 hour.
 ### Result
 
 All nodes are still running, reachable, and the packet buffer is empty 10
-seconds after completions (use module `gnrc_pktbuf_cmd`).
+seconds after completions (use module `shell_cmd_gnrc_pktbuf`).
 Packet loss is irrelevant in this stress test.
 
 Task #05 - ICMPv6 stress test on native (neighbor cache stress)
@@ -78,7 +78,7 @@ one native node.
 ### Result
 
 All nodes are still running, reachable, and the packet buffer is empty 10
-seconds after completions (use module `gnrc_pktbuf_cmd`).
+seconds after completions (use module `shell_cmd_gnrc_pktbuf`).
 Packet loss is irrelevant in this stress test.
 
 Task #06 - ICMPv6 link-local echo on native (IPv6 fragmentation)

--- a/04-single-hop-6lowpan-icmp/README.md
+++ b/04-single-hop-6lowpan-icmp/README.md
@@ -47,7 +47,7 @@ ICMPv6 echo request/reply exchange between two nodes.
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #04 - ICMPv6 echo with iotlab-m3/samr21-xpro 15 minutes
 ============================================================
@@ -149,7 +149,7 @@ to one iotlab-m3.
 ### Result
 
 All nodes are still running, reachable, and the packet buffer is empty 3 seconds
-after completions (use module `gnrc_pktbuf_cmd`).
+after completions (use module `shell_cmd_gnrc_pktbuf`).
 Packet loss is irrelevant in this stress test.
 
 Task #10 (Experimental) - ICMPv6 echo with large payload (IPv6 fragmentation)
@@ -169,7 +169,7 @@ both the fragmented and reassembled requests/replies).
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #11 (Experimental) - ICMPv6 stress test on nrf802154
 =========================================================
@@ -188,7 +188,7 @@ Rapid ICMPv6 echo request/reply exchange between an a nrf802154 based node
 ### Result
 
 All nodes are still running, reachable, and the packet buffer is empty 3 seconds
-after completions (use module `gnrc_pktbuf_cmd`).
+after completions (use module `shell_cmd_gnrc_pktbuf`).
 Packet loss is irrelevant in this stress test.
 
 Task #12 (Experimental) - ICMPv6 multicast echo with iotlab-m3/nrf802154

--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -26,8 +26,8 @@ class Shell(Ifconfig, GNRCICMPv6Echo, GNRCPktbufStats):
 )
 def test_task01(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
@@ -50,8 +50,8 @@ def test_task01(riot_ctrl):
 )
 def test_task02(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged_netif, _ = lladdr(pinged.ifconfig_list())
@@ -73,8 +73,8 @@ def test_task02(riot_ctrl):
 )
 def test_task03(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
@@ -97,8 +97,8 @@ def test_task03(riot_ctrl):
 )
 def test_task04(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
@@ -129,8 +129,8 @@ def test_task04(riot_ctrl):
 def test_task05(riot_ctrl):
     try:
         pinger, pinged = (
-            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+            riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
         )
     except subprocess.CalledProcessError:
         pytest.xfail(
@@ -160,8 +160,8 @@ def test_task05(riot_ctrl):
 def test_task06(riot_ctrl):
     try:
         pinger, pinged = (
-            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+            riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
         )
     except subprocess.CalledProcessError:
         pytest.xfail(
@@ -188,8 +188,8 @@ def test_task06(riot_ctrl):
 )
 def test_task07(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd", "xbee"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf", "xbee"]),
     )
 
     pinged_netif, _ = lladdr(pinged.ifconfig_list())
@@ -210,8 +210,8 @@ def test_task07(riot_ctrl):
 )
 def test_task08(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd", "xbee"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf", "xbee"]),
     )
 
     pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
@@ -233,9 +233,9 @@ def test_task08(riot_ctrl):
 )
 def test_task09(riot_ctrl):
     nodes = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(2, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(2, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged = nodes[0]
@@ -266,8 +266,8 @@ def test_task09(riot_ctrl):
 )
 def test_task10(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, TASK10_APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, TASK10_APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, TASK10_APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, TASK10_APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
@@ -298,9 +298,9 @@ def test_task10(riot_ctrl):
 def test_task11(riot_ctrl):
     try:
         nodes = (
-            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-            riot_ctrl(2, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+            riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+            riot_ctrl(2, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
         )
     except subprocess.CalledProcessError:
         pytest.xfail(
@@ -339,8 +339,8 @@ def test_task11(riot_ctrl):
 def test_task12(riot_ctrl):
     try:
         pinger, pinged = (
-            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+            riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
         )
     except subprocess.CalledProcessError:
         pytest.xfail(
@@ -368,8 +368,8 @@ def test_task12(riot_ctrl):
 def test_task13(riot_ctrl):
     try:
         pinger, pinged = (
-            riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-            riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+            riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+            riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
         )
     except subprocess.CalledProcessError:
         pytest.xfail(

--- a/05-single-hop-route/README.md
+++ b/05-single-hop-route/README.md
@@ -19,7 +19,7 @@ otherwise default routes and address resolution will be auto-configured).
 ### Result
 
 <1% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 
 Task #02 - ICMPv6 echo unicast addresess on iotlab-m3 (default route)
@@ -41,7 +41,7 @@ advertisements for this task).
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #03 - ICMPv6 echo unicast addresess on native (specific route)
 ===================================================================
@@ -62,7 +62,7 @@ otherwise default routes and address resolution will be auto-configured ).
 ### Result
 
 <1% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #04 - ICMPv6 echo unicast addresess on iotlab-m3 (static route)
 ====================================================================

--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -22,8 +22,8 @@ class Shell(Ifconfig, GNRCICMPv6Echo, GNRCPktbufStats, GNRCIPv6NIB):
 )
 def test_task01(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap0"),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap1"),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], port="tap0"),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], port="tap1"),
     )
 
     pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
@@ -49,8 +49,8 @@ def test_task01(riot_ctrl):
 )
 def test_task02(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
     )
 
     pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
@@ -73,8 +73,8 @@ def test_task02(riot_ctrl):
 )
 def test_task03(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap0"),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap1"),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], port="tap0"),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], port="tap1"),
     )
 
     pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())
@@ -99,8 +99,8 @@ def test_task03(riot_ctrl):
 )
 def test_task04(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap0"),
-        riot_ctrl(1, APP, Shell, modules=["gnrc_pktbuf_cmd"], port="tap1"),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], port="tap0"),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], port="tap1"),
     )
 
     pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())

--- a/06-single-hop-udp/README.md
+++ b/06-single-hop-udp/README.md
@@ -16,7 +16,7 @@ Sending UDP between two iotlab-m3 nodes.
 ### Result
 
 <5% packets lost on the receiving node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #02 - UDP on iotlab-m3 (UDP port compression)
 ==================================================
@@ -34,7 +34,7 @@ Sending UDP between two iotlab-m3 nodes.
 ### Result
 
 <5% packets lost on the receiving node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #03 - UDP on native (non-existent neighbor)
 ================================================
@@ -50,7 +50,7 @@ Sending UDP from one native node to a non-existent neighbor.
 
 ### Result
 
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 Packet loss is irrelevant for this test.
 
 Task #04 - UDP on iotlab-m3 (non-existent neighbor)
@@ -68,7 +68,7 @@ Sending UDP from one iotlab-m3 node to a non-existent neighbor.
 
 ### Result
 
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 Packet loss is irrelevant for this test.
 
 Task #05 - Empty UDP on native
@@ -86,7 +86,7 @@ Sending UDP between two native nodes.
 ### Result
 
 <=10% packets lost on the receiving node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #06 - Empty UDP on iotlab-m3
 =================================
@@ -104,4 +104,4 @@ Sending UDP between two iotlab-m3 nodes.
 ### Result
 
 <=10% packets lost on the receiving node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).

--- a/07-multi-hop/README.md
+++ b/07-multi-hop/README.md
@@ -10,7 +10,7 @@ with static routes.
 ### Result
 
 <20% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #02 - UDP on iotlab-m3 with three hops (static route)
 ==========================================================
@@ -21,7 +21,7 @@ Sending UDP between two iotlab-m3 nodes over three hops with static routes.
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #03 - ICMPv6 echo on iotlab-m3 with three hops (RPL route)
 ===============================================================
@@ -33,7 +33,7 @@ with RPL generated routes.
 ### Result
 
 <20% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #04 - UDP on iotlab-m3 with three hops (RPL route)
 =======================================================
@@ -44,7 +44,7 @@ Sending UDP between two iotlab-m3 nodes over three hops with RPL generated route
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).
 
 Task #05 (Experimental) - UDP with large payload on iotlab-m3 with three hops (RPL route)
 =========================================================================================
@@ -58,4 +58,4 @@ requests/replies).
 ### Result
 
 <10% packets lost on the pinging node.
-No leaks in the packet buffer (check with `gnrc_pktbuf_cmd`).
+No leaks in the packet buffer (check with `shell_cmd_gnrc_pktbuf`).

--- a/07-multi-hop/example_test_guide.md
+++ b/07-multi-hop/example_test_guide.md
@@ -8,7 +8,7 @@ node1 <-> node2 <-> node3 <-> node4_
 
 # Task 1 and 2 Setup
 1. First build the firmware for all the nodes
-`USEMODULE=gnrc_pktbuf_cmd make -C tests/gnrc_udp/ BOARD=iotlab-m3 clean all`
+`USEMODULE=shell_cmd_gnrc_pktbuf make -C tests/gnrc_udp/ BOARD=iotlab-m3 clean all`
 1. Open 4 instances of nodes physically close together
 `make -C tests/gnrc_udp/ BOARD=iotlab-m3 IOTLAB_NODE=<iotlab id> flash-only term`
 1. On each end of the nodes add a global IP address (ie. node1:
@@ -58,7 +58,7 @@ No leaks in the packet buffer (check with `pktbuf`).
 
 # Task 3 and 4 Setup
 1. First build the firmware for all the nodes
-`USEMODULE="l2filter_whitelist gnrc_pktbuf_cmd" BOARD=iotlab-m3 make -C tests/gnrc_udp/ clean all`
+`USEMODULE="l2filter_whitelist shell_cmd_gnrc_pktbuf" BOARD=iotlab-m3 make -C tests/gnrc_udp/ clean all`
 1. Flash all nodes with with the l2filter_whitelist module firmware
 `BOARD=iotlab-m3 IOTLAB_NODE=<iotlab id> make -C tests/gnrc_udp/ flash-only term`
 1. Setup the l2filter_whitelist addresses

--- a/11-lorawan/test_spec11.py
+++ b/11-lorawan/test_spec11.py
@@ -203,7 +203,9 @@ def test_task04(riot_ctrl, appeui, deveui, appkey, devaddr, nwkskey, appskey):
 )
 # pylint: disable=R0913
 def test_task05(riot_ctrl, ttn_client, dev_id, deveui, appeui, appkey):
-    node = riot_ctrl(0, GNRC_LORAWAN_APP, ShellGnrcLoRaWAN, modules=["gnrc_pktbuf_cmd"])
+    node = riot_ctrl(
+        0, GNRC_LORAWAN_APP, ShellGnrcLoRaWAN, modules=["shell_cmd_gnrc_pktbuf"]
+    )
 
     iface = lorawan_netif(node)
     assert iface
@@ -242,7 +244,9 @@ def test_task05(riot_ctrl, ttn_client, dev_id, deveui, appeui, appkey):
 @pytest.mark.local_only
 # pylint: disable=R0913
 def test_task06(riot_ctrl, ttn_client, dev_id, devaddr, nwkskey, appskey):
-    node = riot_ctrl(0, GNRC_LORAWAN_APP, ShellGnrcLoRaWAN, modules=["gnrc_pktbuf_cmd"])
+    node = riot_ctrl(
+        0, GNRC_LORAWAN_APP, ShellGnrcLoRaWAN, modules=["shell_cmd_gnrc_pktbuf"]
+    )
 
     iface = lorawan_netif(node)
     assert iface


### PR DESCRIPTION
Replace the deprecated module gnrc_pktbuf_cmd with the new shell_cmd_gnrc_pktbuf module.

See https://github.com/RIOT-OS/RIOT/pull/18355#issuecomment-1256915237