### PR TITLE
09-coap: use URI with `cord_ep register`

### DIFF
--- a/09-coap/README.md
+++ b/09-coap/README.md
@@ -54,7 +54,7 @@ Start a native terminal for the RIOT cord_ep example app.
 
 Register with the RD server with the command:
 ```
-   > cord_ep register [fd00:bbbb::1]
+   > cord_ep register coap://[fd00:bbbb::1]
 ```
 
 You should see the message below in the RIOT native terminal:

--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -89,7 +89,7 @@ def test_task01(riot_ctrl, log_nodes):
         stderr=None if log_nodes else subprocess.DEVNULL,
     )
     try:
-        res = node.cord_ep_register(f"[{HOST_ULA}]")
+        res = node.cord_ep_register(f"coap://[{HOST_ULA}]")
         parser = CordEpRegistrationInfoParser()
         core_reg = parser.parse(res)
         ltime = core_reg['ltime']


### PR DESCRIPTION
The parameter for `cord_ep register` was changed in https://github.com/RIOT-OS/RIOT/pull/18053 to be a full URI, not just a server name + registration interface. This fixes the specs and tests to reflect that. /cc @Teufelchen1