### PR TITLE
08-interop: remove deprecated tasks

### DIFF
--- a/08-interop/README.md
+++ b/08-interop/README.md
@@ -156,11 +156,7 @@ Link-local UDP over IPv6 packet exchange (payload length 8) between an iotlab-m3
 node running RIOT with GNRC and an iotlab-m3 node running RIOT with lwIP (in
 both directions).
 
-Task #09 - deprecated
-=====================
-
-Task #10 - deprecated
-=====================
+<!-- Task 09 and 10 used were deprecated, their slots are free to be newly allocated -->
 
 Task #11 - UDP exchange between iotlab-m3 and Zephyr
 =====================================================


### PR DESCRIPTION
[REPLACED.md](https://github.com/RIOT-OS/Release-Specs/blob/master/REPLACED.md) lists tasks 8.09 and 8.10 as replaceable after 2021-05-01, which was nearly 1,5 years ago. So this just remove the tasks and add a comment about why.