### PR TITLE
tox-envfile: deactivate for now

### DIFF
--- a/.devdata.env.sample
+++ b/.devdata.env.sample
@@ -1,4 +1,6 @@
 # Use this file as a template for .devdata.env
+# Currently not supported, since tox-envfile does not support tox version >= 4
+# https://github.com/hypothesis/tox-envfile/pull/12
 
 ### General
 

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         pyenv="py$(echo "${{ matrix.python-version }}" | tr -d .)"
         cd Release-Specs
-        tox -e "test,${pyenv},flake8,pylint" -- --doctest-modules --self-test \
+        tox -e "test,flake8,pylint" -- --doctest-modules --self-test \
             --cov=testutils --cov-report term-missing \
             --cov-config=testutils/.coveragerc \
             --cov-fail-under=95

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = test,flake8,pylint,black
 skipsdist = True
+skip_missing_interpreters = true
 
 [testenv]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = test,flake8,pylint,black
 skipsdist = True
-requires = tox-envfile
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
This module does not support tox >= 4 and causes an error

    pluggy._manager.PluginValidationError: unknown hook 'tox_configure' in plugin
    <module 'tox_envfile' from ...>

=> deactivate for now.