### PR TITLE
09-coap/test_spec09.py: update coap shell command use

### DIFF
--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -36,7 +36,7 @@ class Shell(Ifconfig, CordEp):
         cmd = "coap get "
         if confirmable:
             cmd += "-c "
-        cmd += f"{addr} {port:d} {resource}"
+        cmd += f"[{addr}]:{port:d} {resource}"
         return self.cmd(cmd, timeout=timeout, async_=async_)
 
 


### PR DESCRIPTION
This should fix

```
> coap get -c fd00:bbbb::1 5683 /time
coap get -c fd00:bbbb::1 5683 /time

usage: coap <get|post|put> [-c] <host>[:port] <path> [data]
       coap ping <host>[:port]
Options
    -c  Send confirmably (defaults to non-confirmable)
```