### PR TITLE
99-compile-and-test-one-board: add note on boards tested in CI

### DIFF
--- a/99-compile-and-test-one-board/README.md
+++ b/99-compile-and-test-one-board/README.md
@@ -12,4 +12,8 @@ Run [`02-tests`][02-tests] procedure with your test board connected.
 
 Please make the result files available to the release manager.
 
+Note: For some boards there are weekly runs in the CI in [test-on-iotlab] and [test-on-ryot].
+
 [02-tests]: ../02-tests
+[test-on-iotlab]: https://github.com/RIOT-OS/RIOT/actions/workflows/test-on-iotlab.yml
+[test-on-ryot]: https://github.com/RIOT-OS/RIOT/actions/workflows/test-on-ryot.yml


### PR DESCRIPTION
See [notes from today's meeting](https://forum.riot-os.org/t/weekly-coordination-call-friday-at-10am-cet/3068/232) (only accessible for maintainers so here is the quote in question):

> martine: You are aware that the CI does on test-on-* ([RYOT](https://github.com/RIOT-OS/RIOT/actions/workflows/test-on-ryot.yml) and [IoT-LAB](https://github.com/RIOT-OS/RIOT/actions/workflows/test-on-iotlab.yml)) do run this on a few boards through CI? No… (maybe mention it in the 99-* doc?)

Apparently, not even recent release managers know about these, so at least mention them in the specs.