### PR TITLE
testutils/test_github: compare stripped bodies

### DIFF
--- a/testutils/tests/test_github.py
+++ b/testutils/tests/test_github.py
@@ -684,7 +684,7 @@ def test_update_comment(
         if gist_id is not None:
             task['gist_id'] = gist_id
         testutils.github.update_comment(_get_mock_report("passed"), comment, task)
-    assert comment.body == exp_body
+    assert comment.body.strip() == exp_body.strip()
     if exp_errs:
         for exp_err in exp_errs:
             assert exp_err in caplog.text


### PR DESCRIPTION
This PR is an attempt to fix the problem raised in #283. The problem seems to come from a trailing "\n" at the end of the body content that is added by BeautifulSoup apparently. I haven't found how to prevent BeautifulSoup from doing that.
So the idea is simply to compare the stripped content of the bodies (computed vs expected).
The other option is to add `\n` to the end of each expected bodies. I can change this PR to that if it's preferred. Or maybe someone knows how to adapt the beautifulsoup code that generates the `tbody` tag.