### PR TITLE
requirements.txt: pin pytest to <7.4 for the moment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ aiocoap[linkheader]>=0.4b3
 beautifulsoup4
 iotlabcli
 pygithub
-pytest
+# https://docs.pytest.org/en/stable/changelog.html#pytest-7-4-0-2023-06-23
+# changed something about testpaths so that `.tox` gets included in certain
+# cases
+pytest<7.4
 pytest-cov
 pytest-rerunfailures
 riotctrl


### PR DESCRIPTION
With this, the release tests should run again in RIOT master.