### PR TITLE
Spec04 use iotlab-m3 and openmote-b

### DIFF
--- a/04-single-hop-6lowpan-icmp/README.md
+++ b/04-single-hop-6lowpan-icmp/README.md
@@ -65,12 +65,12 @@ ICMPv6 echo request/reply exchange between an iotlab-m3 and a samr21-xpro node.
 
 <10% packets lost on the pinging node.
 
-Task #05 (Experimental) - ICMPv6 multicast echo with samr21-xpro/cc2538
+Task #05 (Experimental) - ICMPv6 multicast echo with iotlab-m3/cc2538
 =======================================================================
 ### Description
 
 ICMPv6 echo request/reply exchange between a CC2538 (e.g Zolertia Remote,
-Firefly) and a samr21-xpro node.
+Firefly) and a iotlab-m3 node.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                17
 * Count:                  1000
@@ -82,12 +82,12 @@ Firefly) and a samr21-xpro node.
 
 <10% packets lost on the pinging node.
 
-Task #06 (Experimental)- ICMPv6 link-local echo with samr21-xpro/cc2538
+Task #06 (Experimental)- ICMPv6 link-local echo with iotlab-m3/cc2538
 =======================================================================
 ### Description
 
 ICMPv6 echo request/reply exchange between a CC2538 (e.g Zolertia Remote,
-Firefly) and a samr21-xpro node.
+Firefly) and a iotlab-m3 node.
 * Stack configuration:    6LoWPAN (default)
 * Channel:                26
 * Count:                  1000

--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -123,7 +123,7 @@ def test_task04(riot_ctrl):
 # nodes and iotlab_site passed to riot_ctrl fixture
 @pytest.mark.parametrize(
     'nodes, iotlab_site',
-    [pytest.param(['samr21-xpro', 'firefly'], "lille")],
+    [pytest.param(['iotlab-m3', 'openmote-b'], "strasbourg")],
     indirect=['nodes', 'iotlab_site'],
 )
 def test_task05(riot_ctrl):
@@ -138,9 +138,9 @@ def test_task05(riot_ctrl):
             # pylint: disable=C0301
             "https://github.com/RIOT-OS/Release-Specs/pull/198#issuecomment-756756109"  # noqa: E501
         )
-    pinged_netif, _ = lladdr(pinged.ifconfig_list())
+    pinged_netif, _ = lladdr(pinged.ifconfig_list(), ignore_chan_0=True)
     pinged.ifconfig_set(pinged_netif, "channel", 17)
-    pinger_netif, _ = lladdr(pinger.ifconfig_list())
+    pinger_netif, _ = lladdr(pinger.ifconfig_list(), ignore_chan_0=True)
     pinger.ifconfig_set(pinger_netif, "channel", 17)
 
     res = ping6(pinger, "ff02::1", count=1000, interval=100, packet_size=50)
@@ -154,7 +154,7 @@ def test_task05(riot_ctrl):
 # nodes and iotlab_site passed to riot_ctrl fixture
 @pytest.mark.parametrize(
     'nodes, iotlab_site',
-    [pytest.param(['samr21-xpro', 'firefly'], "lille")],
+    [pytest.param(['iotlab-m3', 'openmote-b'], "strasbourg")],
     indirect=['nodes', 'iotlab_site'],
 )
 def test_task06(riot_ctrl):
@@ -169,10 +169,10 @@ def test_task06(riot_ctrl):
             # pylint: disable=C0301
             "https://github.com/RIOT-OS/Release-Specs/pull/198#issuecomment-758522278"  # noqa: E501
         )
-    pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list())
+    pinged_netif, pinged_addr = lladdr(pinged.ifconfig_list(), ignore_chan_0=True)
     pinged.ifconfig_set(pinged_netif, "channel", 26)
     assert pinged_addr.startswith("fe80::")
-    pinger_netif, _ = lladdr(pinger.ifconfig_list())
+    pinger_netif, _ = lladdr(pinger.ifconfig_list(), ignore_chan_0=True)
     pinger.ifconfig_set(pinger_netif, "channel", 26)
 
     res = ping6(pinger, pinged_addr, count=1000, interval=100, packet_size=100)

--- a/testutils/iotlab.py
+++ b/testutils/iotlab.py
@@ -35,12 +35,13 @@ class IoTLABExperiment:
         'nrf52832-mdk': {'name': 'nrf52832mdk', 'radio': 'ble'},
         'nrf52840dk': {'name': 'nrf52840dk', 'radio': 'multi'},
         'nrf52840-mdk': {'name': 'nrf52840mdk', 'radio': 'multi'},
+        'openmote-b': {'name': 'openmoteb'},
         'pba-d-01-kw2x': {'name': 'phynode', 'radio': 'kw2xrf'},
         'samr21-xpro': {'name': 'samr21', 'radio': 'at86rf233'},
         'samr30-xpro': {'name': 'samr30', 'radio': 'at86rf212b'},
     }
 
-    SITES = ['grenoble', 'lille', 'saclay']
+    SITES = ['grenoble', 'lille', 'saclay', 'strasbourg']
 
     def __init__(self, name, ctrls, site=DEFAULT_SITE):
         IoTLABExperiment._check_site(site)
@@ -57,7 +58,7 @@ class IoTLABExperiment:
         match = re.search(reg, iotlab_node)
         if match is None:
             raise ValueError(
-                "Unable to parse {iotlab_node} as IoT-LAB node "
+                f"Unable to parse {iotlab_node} as IoT-LAB node "
                 "name of format "
                 "<node-name>.<site-name>.iot-lab.info"
             )
@@ -92,6 +93,8 @@ class IoTLABExperiment:
     def _archi_from_board(board):
         """Return iotlab 'archi' format for BOARD"""
         name = IoTLABExperiment.BOARD_ARCHI_MAP[board]['name']
+        if 'radio' not in IoTLABExperiment.BOARD_ARCHI_MAP[board]:
+            return f'{name}'
         radio = IoTLABExperiment.BOARD_ARCHI_MAP[board]['radio']
         return f'{name}:{radio}'
 

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -203,13 +203,19 @@ def first_netif_and_addr_by_scope(ifconfig_out, scope, ignore_chan_0=False):
         if not ignore_chan_0 or netif.get("channel", -1) != 0:
             return (
                 key,
-                [addr["addr"] for addr in netif["ipv6_addrs"] if addr["scope"] == scope][0],
+                [
+                    addr["addr"]
+                    for addr in netif["ipv6_addrs"]
+                    if addr["scope"] == scope
+                ][0],
             )
     raise RuntimeError(f"For valid netifs found in {netifs}")
 
 
 def lladdr(ifconfig_out, ignore_chan_0=False):
-    return first_netif_and_addr_by_scope(ifconfig_out, "link", ignore_chan_0=ignore_chan_0)
+    return first_netif_and_addr_by_scope(
+        ifconfig_out, "link", ignore_chan_0=ignore_chan_0
+    )
 
 
 def global_addr(ifconfig_out):

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -197,18 +197,19 @@ def ifconfig(node, netif=None):
     return res
 
 
-def first_netif_and_addr_by_scope(ifconfig_out, scope):
+def first_netif_and_addr_by_scope(ifconfig_out, scope, ignore_chan_0=False):
     netifs = PARSERS["ifconfig"].parse(ifconfig_out)
-    key = next(iter(netifs))
-    netif = netifs[key]
-    return (
-        key,
-        [addr["addr"] for addr in netif["ipv6_addrs"] if addr["scope"] == scope][0],
-    )
+    for key, netif in netifs.items():
+        if not ignore_chan_0 or netif.get("channel", -1) != 0:
+            return (
+                key,
+                [addr["addr"] for addr in netif["ipv6_addrs"] if addr["scope"] == scope][0],
+            )
+    raise RuntimeError(f"For valid netifs found in {netifs}")
 
 
-def lladdr(ifconfig_out):
-    return first_netif_and_addr_by_scope(ifconfig_out, "link")
+def lladdr(ifconfig_out, ignore_chan_0=False):
+    return first_netif_and_addr_by_scope(ifconfig_out, "link", ignore_chan_0=ignore_chan_0)
 
 
 def global_addr(ifconfig_out):


### PR DESCRIPTION
The lille site doesn't have any engineers there and all `firefly` boards are have ERROR.

As a result, tests using them are failing.  Since the tests try to use a `cc2538` radio, only `strasbourg` seems to have them, though no samr21-xpros.  So we will have to switch to `iotlab-m3` boards.