### PR TITLE
Automate spec08 task03 contiki interop tests

### DIFF
--- a/08-interop/README.md
+++ b/08-interop/README.md
@@ -14,103 +14,134 @@ Task #02 - ICMPv6 echo between iotlab-m3 and Linux with 6LowPAN
 ICMPv6 echo request/reply exchange between an iotlab-m3 node running RIOT and
 a Raspberry Pi running Linux with 6LoWPAN support.
 
-Task #03 - UDP exchange between iotlab-m3 and Contiki
+Task #03 - ICMPv6 echo between RIOT and Contiki-NG
 =====================================================
 ### Description
 
-UDP packet exchange between an iotlab-m3 node running RIOT and a Contiki node.
+ICMPv6 echo request/reply exchange between a node running RIOT and a Contiki node.
 
 ### Testing procedure
-1. Get your hands on a [CC2538DK evaluation board][cc2538dk]
-1. Clone the Contiki repository to your machine
-   ```sh
-   git clone http://github.com/contiki-os/contiki.git && cd contiki/
-   ```
-2. Go to the `udp-ipv6-echo-server` for the CC2538DK:
-   ```sh
-   cd examples/cc2538dk/udp-ipv6-echo-server
-   ```
-3. Apply the following patch
-   ```sh
-   echo 'diff --git a/examples/cc2538dk/udp-ipv6-echo-server/Makefile b/examples/cc2538dk/udp-ipv6-echo-server/Makefile
-   index 5bbbdd6..92ec1c5 100644
-   --- a/examples/cc2538dk/udp-ipv6-echo-server/Makefile
-   +++ b/examples/cc2538dk/udp-ipv6-echo-server/Makefile
-   @@ -1,8 +1,12 @@
-   +DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
-    CONTIKI_PROJECT = udp-echo-server
+This assummes Docker is installed and configured. The steps for configuring
+Contiki-NG are based on the [official documentation](https://docs.contiki-ng.org/en/master/doc/getting-started/index.html)
 
-    all: $(CONTIKI_PROJECT)
+1. Clone Contiki-NG
 
-    CONTIKI = ../../..
-   +CONTIKI_WITH_RIME = 0
-    CONTIKI_WITH_IPV6 = 1
-    CFLAGS += -DUIP_CONF_ND6_SEND_NS=1
-   +CFLAGS += -DRF_CHANNEL=26
-   +CFLAGS += -DIEEE802154_CONF_PANID=0x23
-    include $(CONTIKI)/Makefile.include
-   diff --git a/examples/cc2538dk/udp-ipv6-echo-server/project-conf.h b/examples/cc2538dk/udp-ipv6-echo-server/project-conf.h
-   new file mode 100644
-   index 0000000..1718ded
-   --- /dev/null
-   +++ b/examples/cc2538dk/udp-ipv6-echo-server/project-conf.h
-   @@ -0,0 +1,4 @@
-   +#ifndef PROJECT_CONF_H_
-   +#define PROJECT_CONF_H_
-   +#define NETSTACK_CONF_RDC     nullrdc_driver
-   +#endif /* PROJECT_CONF_H_ */' | git apply
-   ```
-4. Build the application with
-   ```
-   make
-   ```
-5. **Switch to your RIOT repository**
-6. Switch the CC2538DK into bootloader mode by holding SELECT, then pressing
-   EM RESET, and then releasing SELECT (there should be no LED blinking when
-   you release RESET)
-7. Use `dist/tools/cc2538-bsl/cc2538-bsl.py` to flash the *Contiki* application
-   to the CC2538DK.
-   You first need to fetch it from upstream.
-   ```sh
-   make -C examples/hello-world/ ${PWD}/dist/tools/cc2538-bsl/cc2538-bsl.py
-   dist/tools/cc2538-bsl/cc2538-bsl.py -e -w -v -p /dev/ttyUSB1 \
-        "<contiki repo>"/examples/cc2538dk/udp-ipv6-echo-server/udp-echo-server.bin
-   ```
-   *Note:* If you encounter any problems the [cc2538dk] documentation might help
-   you.
-8. Use either `pyterm` or a sniffer to find out the Contiki node's link local
-   address. With the sniffer just copy the source address of the first RPL
-   package you see (assuming there are no other IEEE 802.15.4 nodes around you
-   😉). With `pyterm` you will see something like
+```bash
+git clone https://github.com/contiki-ng/contiki-ng.git
+cd contiki-ng
+git submodule update --init --recursive
 
-        Rime configured with address 00:12:34:56:78:9a:bc:de
+```
 
-   in the output.
+2. Pull the Contiki-NG Docker image
 
-   You might have seen this address also during flashing
+```bash
+docker pull contiker/contiki-ng
+```
 
-        Primary IEEE Address: 00:12:34:56:78:9A:BC:DE
+3. Create a `contiker` alias to start the Contiki-NG environment
+```bash
 
-   You can get the IPv6 link local address of the node by toggling the second
-   bit of the MSB of the address and prepending `fe80::`. So for the example
-   above that would be `fe80::0212:3456:789a:bcde`.
-7. For the `iotlab-m3` side just use [gnrc_networking] or the [gnrc_udp] test
-   application, whichever you prefer. There start a UDP server on port 3000 with
+export CNG_PATH=<absolute-path-to-your-contiki-ng>
+alias contiker="docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/bus/usb:/dev/bus/usb -ti contiker/contiki-ng"
 
-        > udp server start 3000
+```
 
-   and send a UDP packet to port 3000 of the CC2538DK/Contiki node:
+4. Add the `shell` service to the `examples/hello-world` application.
+```diff
+diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
+index 0a79167ae..710496368 100644
+--- a/examples/hello-world/Makefile
++++ b/examples/hello-world/Makefile
+@@ -1,5 +1,7 @@
+ CONTIKI_PROJECT = hello-world
+ all: $(CONTIKI_PROJECT)
+ 
++MODULES += os/services/shell
++
+ CONTIKI = ../..
+ include $(CONTIKI)/Makefile.include
+```
 
-        > udp send <contiki ll-addr> 3000 <data>
+5. Run the Contiki-NG environment using the `contiker` alias.
 
-   Every packet you send should be echoed by the CC2538DK/Contiki node and
-   printed to the console (you might need to send more than once since the
-   neighbor discovery of Contiki is not queueing packets for unknown
-   destinations).
+```bash
+contiker
+```
+6. Compile the `hello-world` application for your target platform. Check the
+[platform documentation](https://docs.contiki-ng.org/en/master/doc/platforms/index.html)
+for board specific steps. E.g for `nrf52840dk`:
+```
+make -C examples/hello-world TARGET=nrf52840 hello-world
+make -C examples/hello-world TARGET=nrf52840 hello-world.upload
+```
 
-[cc2538dk]: http://doc.riot-os.org/group__boards__cc2538dk.html
-[gnrc_networking]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking
-[gnrc_udp]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking
+7. Use any serial terminal (e.g `pyterm`) to get the link-local IP address of
+the Contiki-NG node:
+```
+ip-addr
+2023-04-14 15:23:36,732 # #f4ce.36c6.d8d1.e340> Node IPv6 addresses:
+2023-04-14 15:23:36,735 # -- fe80::f6ce:36c6:d8d1:e340
+```
+
+8. For the RIOT side just use [gnrc_networking](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking). Get the link-local IP address with `ifconfig`:
+
+```
+2023-04-14 15:11:12,614 # ifconfig
+2023-04-14 15:11:12,620 # Iface  6  HWaddr: 06:EE  Channel: 26  NID: 0xabcd  PHY: O-QPSK 
+2023-04-14 15:11:12,622 #           
+2023-04-14 15:11:12,626 #           Long HWaddr: 00:04:25:19:18:01:86:EE 
+2023-04-14 15:11:12,633 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
+2023-04-14 15:11:12,640 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
+2023-04-14 15:11:12,643 #           RTR_ADV  6LO  IPHC  
+2023-04-14 15:11:12,646 #           Source address length: 8
+2023-04-14 15:11:12,649 #           Link type: wireless
+2023-04-14 15:11:12,655 #           inet6 addr: fe80::204:2519:1801:86ee  scope: link  VAL
+2023-04-14 15:11:12,665 #           inet6 group: ff02::2
+2023-04-14 15:11:12,668 #           inet6 group: ff02::1
+2023-04-14 15:11:12,672 #           inet6 group: ff02::1:ff01:86ee
+2023-04-14 15:11:12,674 #           inet6 group: ff02::1a
+2023-04-14 15:11:12,675 #           
+2023-04-14 15:11:12,678 #           Statistics for Layer 2
+2023-04-14 15:11:12,682 #             RX packets 16174  bytes 1812690
+2023-04-14 15:11:12,688 #             TX packets 14824 (Multicast: 82)  bytes 1715052
+2023-04-14 15:11:12,692 #             TX succeeded 14694 errors 130
+2023-04-14 15:11:12,694 #           Statistics for IPv6
+2023-04-14 15:11:12,698 #             RX packets 3194  bytes 1453638
+2023-04-14 15:11:12,704 #             TX packets 2545 (Multicast: 82)  bytes 1430068
+2023-04-14 15:11:12,707 #             TX succeeded 2545 errors 0
+2023-04-14 15:11:12,707 # 
+```
+
+9. Set the PAN ID of the RIOT node to `abcd` (default PAN ID of Contiki)
+
+```
+ifconfig 6 set pan_id abcd
+```
+
+10. Run the `ping` command on both the RIOT and the Contiki-NG node:
+
+Contiki-NG:
+```
+ping fe80::204:2519:1801:86ee
+2023-04-14 15:23:29,960 # #f4ce.36c6.d8d1.e340> Pinging fe80::204:2519:1801:86ee
+2023-04-14 15:23:29,974 # Received ping reply from fe80::204:2519:1801:86ee, len 4, ttl 64, delay 15 ms
+```
+
+RIOT
+```
+ping fe80::f6ce:36c6:d8d1:e340
+2023-04-14 15:30:20,415 # ping fe80::f6ce:36c6:d8d1:e340
+2023-04-14 15:30:20,449 # 12 bytes from fe80::f6ce:36c6:d8d1:e340%6: icmp_seq=0 ttl=64 rssi=-46 dBm time=24.320 ms
+2023-04-14 15:30:21,441 # 12 bytes from fe80::f6ce:36c6:d8d1:e340%6: icmp_seq=1 ttl=64 rssi=-46 dBm time=6.031 ms
+2023-04-14 15:30:22,455 # 12 bytes from fe80::f6ce:36c6:d8d1:e340%6: icmp_seq=2 ttl=64 rssi=-46 dBm time=8.237 ms
+2023-04-14 15:30:22,455 # 
+2023-04-14 15:30:22,460 # --- fe80::f6ce:36c6:d8d1:e340 PING statistics ---
+2023-04-14 15:30:22,465 # 3 packets transmitted, 3 packets received, 0% packet loss
+2023-04-14 15:30:22,469 # round-trip min/avg/max = 6.031/12.862/24.320 ms
+```
+
+Every packet should be echoed by the target node and printed to the console.
 
 Task #04 - ICMPv6 echo between iotlab-m3 and Internet host through Linux with 6LowPAN
 =====================================================================================

--- a/08-interop/compile_contiki.sh
+++ b/08-interop/compile_contiki.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cd /tmp
+
+# Clone Contiki-NG
+git clone https://github.com/contiki-ng/contiki-ng.git; cd contiki-ng || \
+cd contiki-ng; git pull
+git submodule update --init --recursive
+
+# Pull the Contiki-NG Docker image
+docker pull contiker/contiki-ng
+
+# Add the `shell` service to the `examples/hello-world` application.
+if ! grep -q "MODULES += os/services/shell" examples/hello-world/Makefile; then
+    sed -i '/all: $(CONTIKI_PROJECT)/a\\nMODULES += os/services/shell\n' examples/hello-world/Makefile
+fi
+
+
+# Compile the `examples/hello-world` application for the nRF52840 platform.
+export CNG_PATH=/tmp/contiki-ng
+docker run \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng \
+    contiker/contiki-ng \
+    make -C examples/hello-world TARGET=nrf52840 hello-world


### PR DESCRIPTION
This is based off the work @jia200x did.

Still a WIP but here are the issues I have found so far.

- There is no easy way to setup and get the contiki binary so I added a script that can be run and re-run to do so (for local testing... still needs some cleanup)
- We can override `FLASHFILE` to use the existing `riotctrl` infrastructure but `iotlabs` actually uses `BINFILE` to speed things up... that took me a while
- Some hacks were needed in order to use the `flash-only` step maybe that could be cleaned
- Somehow the captured output seems to be a bit funny for the last ping6 command that is wrapped, maybe better to just do it manually.
<details>

```
NETOPT_TX_END_IRQ not implemented by driver
main(): This is RIOT! (Version: 2024.01-devel-11-g354e1-2023.10-branch)
RIOT network stack example application
All up, running the shell now
> NETOPT_TX_END_IRQ not implemented by driver
main(): This is RIOT! (Ve

> ifconfig
ifconfig
Iface  6  HWaddr: 2A:E9  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: DA:A0:4C:0F:6D:85:2A:E9 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::d8a0:4c0f:6d85:2ae9  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff85:2ae9
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 5 (Multicast: 5)  bytes 0
            TX succeeded 4 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 4 (Multicast: 4)  bytes 242
            TX succeeded 4 errors 0

> ssh -t weoss@saclay.iot-lab.info 'socat - tcp:nrf52840dk-6.saclay.iot-lab.info:20000' 
[INFO: Main      ] Starting Contiki-NG-develop/v4.9-407-g1707d485d-dirty
[INFO: Main      ] - Routing: RPL Lite
[INFO: Main      ] - Net: sicslowpan
[INFO: Main      ] - MAC: CSMA
[INFO: Main      ] - 802.15.4 PANID: 0xabcd
[INFO: Main      ] - 802.15.4 De
#f4ce.36c3.4db0.1d35> ip-addr
Node IPv6 addresses:
-- fe80::f6ce:36c3:4db0:1d35
#f4ce.36c3.4db0.1d35> ifconfig 6 set pan_id abcd
ifconfig 6 set pan_id abcd
success: set network identifier on interface 6 to 0xabcd
> ping fe80::d8a0:4c0f:6d85:2ae9
Pinging fe80::d8a0:4c0f:6d85:2ae9
Received ping reply from fe80::d8a0:4c0f:6d85:2ae9, len 4, ttl 64, delay 46 ms
#f4ce.36c3.4db0.1d35> PING START ================
ping fe80::f6ce:36c3:4db0:1d35
ping fe80::f6ce:36c3:4db0:1d35
12 bytes from fe80::f6ce:36c3:4db0:1d35%6: icmp_seq=0 ttl=64 rssi=56 dBm time=45.523 ms
12 bytes from fe80::f6ce:36c3:4db0:1d35%6: icmp_seq=1 ttl=64 rssi=56 dBm time=22.077 ms
12 bytes from fe80::f6ce:36c3:4db0:1d35%6: icmp_seq=2 ttl=64 rssi=56 dBm time=5.378 ms

--- fe80::f6ce:36c3:4db0:1d35 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 5.378/24.326/45.523 ms
> #f4ce.36c3.4db0.1d35 -c 3 -i 1 -s 12 -W 1000
#f4ce.36c3.4db0.1d35 -c 3 -i 1 -s 12 -W 1000
shell: command not found: #f4ce.36c3.4db0.1d35
```
</details>

This is a quick (not really that quick) and dirty way and I would appreciate suggestions on how to clean it up.