### PR TITLE
08-interop: Fix contiki script for workflow

### DIFF
--- a/08-interop/compile_contiki.sh
+++ b/08-interop/compile_contiki.sh
@@ -19,7 +19,8 @@ fi
 # Compile the `examples/hello-world` application for the nRF52840 platform.
 export CNG_PATH=/tmp/contiki-ng
 docker run \
-    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    -e LOCAL_UID=$(id -u $USER) \
+    -e LOCAL_GID=$(id -g $USER) \
     --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng \
     contiker/contiki-ng \
     make -C examples/hello-world TARGET=nrf52840 hello-world


### PR DESCRIPTION
It seems like there were some permission issues only on the github actions runners... Oops.

I guess this [solves it](https://github.com/RIOT-OS/RIOT/actions/runs/6770192155/job/18398079073#step:15:56)