### PR TITLE
conftest: use "native" RIOT_TERMINAL for native boards

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -279,6 +279,10 @@ def nodes(local, request, boards, iotlab_site):
     for board in boards:
         if local or only_native or IoTLABExperiment.valid_board(board):
             env = {'BOARD': f'{board}'}
+            if only_native:
+                # XXX this does not work for a mix of native and non-native boards,
+                # but we do not have these in the release tests at the moment.
+                env["RIOT_TERMINAL"] = "native"
         else:
             env = {
                 'BOARD': IoTLABExperiment.board_from_iotlab_node(board),


### PR DESCRIPTION
Does what https://github.com/RIOT-OS/RIOT/pull/20215 did to the release tests.