### PR TITLE
Fix failing spec05 and task02 test

### DIFF
--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -56,8 +56,8 @@ def test_task01(riot_ctrl):
 )
 def test_task02(riot_ctrl):
     pinger, pinged = (
-        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
-        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"]),
+        riot_ctrl(0, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], cflags="-DCONFIG_IEEE802154_DEFAULT_CHANNEL=13"),
+        riot_ctrl(1, APP, Shell, modules=["shell_cmd_gnrc_pktbuf"], cflags="-DCONFIG_IEEE802154_DEFAULT_CHANNEL=13"),
     )
 
     pinged_netif, pinged_lladdr = lladdr(pinged.ifconfig_list())

--- a/testutils/github.py
+++ b/testutils/github.py
@@ -210,9 +210,9 @@ def create_comment(github, issue):
 def _generate_outcome_summary(pytest_report, task):
     # pylint: disable=C0209
     return "<strong>{a_open}{outcome}{a_close}</strong>".format(
-        a_open='<a href="{}">'.format(task["outcome_url"])
-        if "outcome_url" in task
-        else '',
+        a_open=(
+            '<a href="{}">'.format(task["outcome_url"]) if "outcome_url" in task else ''
+        ),
         outcome=pytest_report.outcome.upper(),
         a_close='</a>' if "outcome_url" in task else '',
     )

--- a/testutils/iotlab.py
+++ b/testutils/iotlab.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import re
 
 from iotlabcli.auth import get_user_credentials
@@ -55,14 +56,14 @@ class IoTLABExperiment:
     def board_from_iotlab_node(iotlab_node):
         """Return BOARD matching iotlab_node"""
         reg = r'([0-9a-zA-Z\-]+)-\d+\.[a-z]+\.iot-lab\.info'
-        match = re.search(reg, iotlab_node)
-        if match is None:
+        matches = re.findall(reg, iotlab_node)
+        if not matches:
             raise ValueError(
                 f"Unable to parse {iotlab_node} as IoT-LAB node "
                 "name of format "
                 "<node-name>.<site-name>.iot-lab.info"
             )
-        iotlab_node_name = match.group(1)
+        iotlab_node_name = random.choice(matches)
         dict_values = IoTLABExperiment.BOARD_ARCHI_MAP.values()
         dict_names = [value['name'] for value in dict_values]
         dict_keys = list(IoTLABExperiment.BOARD_ARCHI_MAP.keys())

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -222,6 +222,22 @@ def global_addr(ifconfig_out):
     return first_netif_and_addr_by_scope(ifconfig_out, "global")
 
 
+def has_global_addr(node):
+    """Check if node has a global address."""
+    try:
+        global_addr(node.ifconfig_list())
+    except (RuntimeError, IndexError):
+        return False
+    return True
+
+
+def try_to_remove_global_addr(node):
+    """Try to remove global address from node."""
+    if has_global_addr(node):
+        netif, addr = global_addr(node.ifconfig_list())
+        node.cmd(f"ifconfig {netif} del {addr}")
+
+
 def check_pktbuf(*nodes, wait=10):
     if wait:
         time.sleep(wait)

--- a/testutils/tests/test_github.py
+++ b/testutils/tests/test_github.py
@@ -983,9 +983,11 @@ def test_upload_results(
     monkeypatch.setattr(
         testutils.github,
         "get_results_gist",
-        lambda *args, **kwargs: (testutils.github.Git('.'), "", "the_gist_id")
-        if gist_created
-        else (None, None, None),
+        lambda *args, **kwargs: (
+            (testutils.github.Git('.'), "", "the_gist_id")
+            if gist_created
+            else (None, None, None)
+        ),
     )
     monkeypatch.setattr(
         testutils.github, "upload_result_content", lambda *args, **kwargs: head


### PR DESCRIPTION
It seems there is a border router running in the IOT lab infrastructure that is giving the test nodes an address.

See https://github.com/RIOT-OS/RIOT/pull/20295 for some info.

While playing around with it I found that removing the address and adding in the spec address doesn't seem to work... Only changing `CONFIG_IEEE802154_DEFAULT_CHANNEL` so it never gets an address in the first place seems to make it function.

Maybe we should be hardened against it but it would be nice to know why removing and shuffling the pan_id and channel doesn't allow it to work.