### PR TITLE
conftest: Randomize default PAN_ID

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ Central pytest definitions.
 See https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions
 """  # noqa: E501
 
+import random
 import re
 import os
 import subprocess
@@ -29,6 +30,7 @@ IOTLAB_EXPERIMENT_DURATION = 120
 RIOTBASE = os.environ.get('RIOTBASE')
 RUNNING_CTRLS = []
 RUNNING_EXPERIMENTS = []
+DEFAULT_PAN_ID = str(random.randint(0, 0xFFFD))
 
 
 def pytest_addoption(parser):
@@ -320,6 +322,12 @@ def update_env(node, modules=None, cflags=None, port=None, termflags=None, extra
         node.env['DOCKER_ENVIRONMENT_CMDLINE'] = (
             node.env.get('DOCKER_ENVIRONMENT_CMDLINE', '')
             + f" -e 'USEMODULE={node.env['USEMODULE']}'"
+        )
+    node.env['DEFAULT_PAN_ID'] = DEFAULT_PAN_ID
+    if os.environ.get('BUILD_IN_DOCKER', 0) == '1':
+        node.env['DOCKER_ENVIRONMENT_CMDLINE'] = (
+            node.env.get('DOCKER_ENVIRONMENT_CMDLINE', '')
+            + f" -e 'DEFAULT_PAN_ID={node.env['DEFAULT_PAN_ID']}'"
         )
     if cflags is not None:
         node.env['CFLAGS'] = cflags


### PR DESCRIPTION
Due to some issues with other border routers running we should harden the tests against that by using a random PAN_ID.

See https://github.com/RIOT-OS/Release-Specs/pull/299 for some info (it contains a train of references)