### PR TITLE
testutils: Avoid deprecated parameter

### DIFF
--- a/testutils/github.py
+++ b/testutils/github.py
@@ -4,7 +4,7 @@ import re
 import urllib.parse
 
 from bs4 import BeautifulSoup
-from github import Github, GithubException, InputFileContent
+from github import Auth, Github, GithubException, InputFileContent
 
 from testutils.git import Git, GitError
 
@@ -80,7 +80,7 @@ def get_github():
     access_token = get_access_token()
     if not access_token:
         return None
-    return Github(access_token, base_url=API_URL)
+    return Github(auth=Auth.Token(access_token), base_url=API_URL)
 
 
 def get_repo(github):


### PR DESCRIPTION
The `login_or_token` parameter of the Github class [is deprecated](https://pygithub.readthedocs.io/en/stable/github.html#github.MainClass.Github). See also [here](https://github.com/RIOT-OS/RIOT/actions/runs/7725056382/job/21058488281#step:15:59). To prevent future surprises, let's port over to the recommended alternative, before it gets dropped.