### PR TITLE
requirements.txt: pin paho to <2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pytest-cov
 pytest-rerunfailures
 riotctrl
 scapy
-paho-mqtt
+paho-mqtt<2


### PR DESCRIPTION
The step to paho 2.0.0 [killed our release tests](https://github.com/RIOT-OS/RIOT/actions/runs/7938879612/job/21678272017). This fixes the tests for now, until the `ttn` module is adopted for the new paho API.