### PR TITLE
09-coap: pass URI instead of separate host and path components

### DIFF
--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -36,7 +36,7 @@ class Shell(Ifconfig, CordEp):
         cmd = "coap get "
         if confirmable:
             cmd += "-c "
-        cmd += f"[{addr}]:{port:d} {resource}"
+        cmd += f"coap://[{addr}]:{port:d}{resource}"
         return self.cmd(cmd, timeout=timeout, async_=async_)
 
 


### PR DESCRIPTION
adapts the test to the changes from https://github.com/RIOT-OS/RIOT/pull/20554