### PR TITLE
fix: Change iotlabs DEFAULT_SITE to grenoble

### DIFF
--- a/testutils/iotlab.py
+++ b/testutils/iotlab.py
@@ -13,7 +13,7 @@ from iotlabcli.experiment import (
 )
 
 
-DEFAULT_SITE = 'saclay'
+DEFAULT_SITE = 'grenoble'
 IOTLAB_DOMAIN = 'iot-lab.info'
 
 


### PR DESCRIPTION
It seems like saclay has a bunch of broken nodes on it, maybe grenoble is a bit better maintained...