### PR TITLE
treewide: update links to RIOT examples

### DIFF
--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -9,7 +9,7 @@ from testutils.asyncio import wait_for_futures
 from testutils.shell import ping6, lladdr, check_pktbuf
 
 
-APP = 'examples/gnrc_networking'
+APP = 'examples/networking/gnrc/gnrc_networking'
 TASK10_APP = 'tests/net/gnrc_udp'
 pytestmark = pytest.mark.rc_only()
 

--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -7,7 +7,7 @@ from testutils.native import bridged
 from testutils.shell import ping6, lladdr, check_pktbuf
 
 
-APP = 'examples/gnrc_networking'
+APP = 'examples/networking/gnrc/gnrc_networking'
 pytestmark = pytest.mark.rc_only()
 
 

--- a/08-interop/README.md
+++ b/08-interop/README.md
@@ -84,7 +84,7 @@ ip-addr
 2023-04-14 15:23:36,735 # -- fe80::f6ce:36c6:d8d1:e340
 ```
 
-8. For the RIOT side just use [gnrc_networking](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking). Get the link-local IP address with `ifconfig`:
+8. For the RIOT side just use [gnrc_networking](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc/gnrc_networking). Get the link-local IP address with `ifconfig`:
 
 ```
 2023-04-14 15:11:12,614 # ifconfig
@@ -344,7 +344,7 @@ The credentials for the WiFi network will be passed on the command line.
 Replace `esp8266-esp-12x` with the esp* board of your choice, adjust `PORT` if needed.
 
 ```
-USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/gnrc_border_router BOARD=esp<...> UPLINK=wifi WIFI_SSID=<your_ssd> WIFI_PASS=<your_password> PORT=<port> flash term
+USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/networking/gnrc/gnrc_border_router BOARD=esp<...> UPLINK=wifi WIFI_SSID=<your_ssd> WIFI_PASS=<your_password> PORT=<port> flash term
 ```
 
 ### Result
@@ -413,7 +413,7 @@ Use the `sock_dns` and `gnrc_ipv6_nib_dns` modules to enable name resolution.
 Replace `esp8266-esp-12x` with the esp* board of your choice, adjust `PORT` if needed.
 
 ```
-USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/gnrc_networking BOARD=esp<…> PORT=<port> flash term
+USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/networking/gnrc/gnrc_networking BOARD=esp<…> PORT=<port> flash term
 ```
 
 ### Result

--- a/08-interop/test_spec08.py
+++ b/08-interop/test_spec08.py
@@ -14,7 +14,7 @@ from testutils.native import bridge, get_link_local, get_ping_cmd, interface_exi
 from testutils.shell import lladdr, ping6, GNRCUDP
 
 
-GNRC_APP = 'examples/gnrc_networking'
+GNRC_APP = 'examples/networking/gnrc/gnrc_networking'
 LWIP_APP = 'tests/pkg/lwip'
 pytestmark = pytest.mark.rc_only()
 

--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -78,7 +78,7 @@ def teardown_function(function):
 @pytest.mark.skipif(not interface_exists("tap0"), reason="tap0 does not exist")
 @pytest.mark.parametrize('nodes', [pytest.param(['native'])], indirect=['nodes'])
 def test_task01(riot_ctrl, log_nodes):
-    node = riot_ctrl(0, 'examples/cord_ep', Shell, port=TAP)
+    node = riot_ctrl(0, 'examples/networking/cord/cord_ep', Shell, port=TAP)
 
     node_netif, _ = lladdr(node.ifconfig_list())
     node.ifconfig_add(node_netif, NODE_ULA)
@@ -116,7 +116,7 @@ def test_task01(riot_ctrl, log_nodes):
     indirect=['nodes'],
 )
 def test_task02(riot_ctrl, start_server, expected):
-    node = riot_ctrl(0, 'examples/gcoap', Shell, port=TAP)
+    node = riot_ctrl(0, 'examples/networking/coap/gcoap', Shell, port=TAP)
 
     node_netif, _ = lladdr(node.ifconfig_list())
     node.ifconfig_add(node_netif, NODE_ULA)
@@ -145,7 +145,7 @@ def test_task02(riot_ctrl, start_server, expected):
 @pytest.mark.skipif(not interface_exists("tap0"), reason="tap0 does not exist")
 @pytest.mark.parametrize('nodes', [pytest.param(['native'])], indirect=['nodes'])
 def test_task03(riot_ctrl):
-    node = riot_ctrl(0, 'examples/nanocoap_server', Shell, port=TAP)
+    node = riot_ctrl(0, 'examples/networking/coap/nanocoap_server', Shell, port=TAP)
     host_netif = bridge(TAP)
 
     # can't use shell interactions here, as there is no shell
@@ -192,7 +192,7 @@ def test_task03(riot_ctrl):
 @pytest.mark.skipif(not interface_exists("tap0"), reason="tap0 does not exist")
 @pytest.mark.parametrize('nodes', [pytest.param(['native'])], indirect=['nodes'])
 def test_task04(riot_ctrl):
-    node = riot_ctrl(0, 'examples/nanocoap_server', Shell, port=TAP)
+    node = riot_ctrl(0, 'examples/networking/coap/nanocoap_server', Shell, port=TAP)
     host_netif = bridge(TAP)
 
     # can't use shell interactions here, as there is no shell
@@ -237,7 +237,7 @@ def test_task04(riot_ctrl):
 @pytest.mark.skipif(not interface_exists("tap0"), reason="tap0 does not exist")
 @pytest.mark.parametrize('nodes', [pytest.param(['native'])], indirect=['nodes'])
 def test_task05(riot_ctrl):
-    node = riot_ctrl(0, 'examples/gcoap', Shell, port=TAP)
+    node = riot_ctrl(0, 'examples/networking/coap/gcoap', Shell, port=TAP)
 
     node_netif, _ = lladdr(node.ifconfig_list())
     node.ifconfig_add(node_netif, NODE_ULA)

--- a/10-icmpv6-error/README.md
+++ b/10-icmpv6-error/README.md
@@ -224,7 +224,7 @@ hop link but not the second hop link via a native node from a Linux host.
 
         $ GNRC_NETIF_NUMOF=2 USEMODULE="socket_zep netdev_tap" \
           CFLAGS=-DGNRC_IPV6_NIB_CONF_SLAAC=1 TERMFLAGS="-z [::]:17755 tap0" \
-            make -C examples/gnrc_networking clean all term
+            make -C examples/networking/gnrc/gnrc_networking clean all term
 
 4. Add `beef::/64` route via TAP interface on RIOT side:
 

--- a/10-icmpv6-error/test_spec10.py
+++ b/10-icmpv6-error/test_spec10.py
@@ -35,7 +35,7 @@ from testutils.native import (
 )
 
 
-APP = 'examples/gnrc_networking'
+APP = 'examples/networking/gnrc/gnrc_networking'
 TAP = 'tap0'
 NETIF_PARSER = IfconfigListParser()
 

--- a/11-lorawan/README.md
+++ b/11-lorawan/README.md
@@ -9,9 +9,9 @@ LoRaWAN example is fully functional
 
 ### Testing procedure
 
-Build and flash the `examples/lorawan` application with the following command
+Build and flash the `examples/networking/misc/lorawan` application with the following command
 
-    $ make BOARD=<board> DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> -C examples/lorawan flash term
+    $ make BOARD=<board> DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> -C examples/networking/misc/lorawan flash term
 
 _Note:_ The application can be tested on IoT-LAB with a device register on
 TheThingsNetwork backend: start an experiment with one of the st-lrwan1 boards
@@ -199,9 +199,9 @@ send/receive LoRaWAN frames.
 
 ### Testing procedure
 
-- Build and flash the `examples/gnrc_lorawan`
+- Build and flash the `examples/networking/gnrc/gnrc_lorawan`
 
-      $ make BOARD=<board> -C examples/gnrc_lorawan flash term
+      $ make BOARD=<board> -C examples/networking/gnrc/gnrc_lorawan flash term
 
 - Configure the device EUI, application EUI, application the `ifconfig` command
 

--- a/11-lorawan/test_spec11.py
+++ b/11-lorawan/test_spec11.py
@@ -10,8 +10,8 @@ from testutils.shell import GNRCLoRaWANSend, ifconfig, lorawan_netif
 from testutils.shell import check_pktbuf
 
 
-GNRC_LORAWAN_APP = "examples/gnrc_lorawan"
-LORAWAN_APP = "examples/lorawan"
+GNRC_LORAWAN_APP = "examples/networking/gnrc/gnrc_lorawan"
+LORAWAN_APP = "examples/networking/misc/lorawan"
 SEMTECH_LORAMAC_APP = "tests/pkg/semtech-loramac"
 pytestmark = pytest.mark.rc_only()
 

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -27,7 +27,7 @@ class GNRCUDPClientSendParser(ShellInteractionParser):
     """
     Shell interaction parser for
 
-    - $RIOTBASE/examples/gnrc_networking
+    - $RIOTBASE/examples/networking/gnrc/gnrc_networking
     - $RIOTBASE/tests/net/gnrc_udp.
 
     As the `udp` shell command is application specific, a central
@@ -78,7 +78,7 @@ class GNRCLoRaWANSend(ShellInteraction):
     """
     Shell interaction for
 
-    - $RIOTBASE/examples/gnrc_lorawan
+    - $RIOTBASE/examples/networking/gnrc/gnrc_lorawan
 
     As the `send` shell command is application specific, a central
     ShellInteraction in `riotctrl_shell` does not make much sense
@@ -99,7 +99,7 @@ class GNRCUDP(ShellInteraction):
     """
     Shell interaction for
 
-    - $RIOTBASE/examples/gnrc_networking
+    - $RIOTBASE/examples/networking/gnrc/gnrc_networking
     - $RIOTBASE/tests/net/gnrc_udp.
 
     As the `udp` shell command is application specific, a central


### PR DESCRIPTION
As follow-up of https://github.com/RIOT-OS/RIOT/pull/21135 and https://github.com/RIOT-OS/RIOT/pull/21221

(Note that any workflow is expected to fail until the latter PR is merged)