### PR TITLE
08-interop: use existing RIOT example folder for flashing

### DIFF
--- a/08-interop/test_spec08.py
+++ b/08-interop/test_spec08.py
@@ -66,7 +66,7 @@ def test_task03(riot_ctrl):
         riot_ctrl(0, GNRC_APP, Shell),
         riot_ctrl(
             1,
-            'examples/hello-world',
+            'examples/basic/hello-world',
             riotctrl.shell.ShellInteraction,
             extras={"BINFILE": contiki_bin_file},
         ),


### PR DESCRIPTION
Follow-up of #319. While the contiki example is indeed still called `examples/hello-world`, the test uses the RIOT build system to flash it on the board. We thus need to specify an existing RIOT application folder for flashing.