### PR TITLE
09-coap: do not expect a specific board name

### DIFF
--- a/09-coap/task04.py
+++ b/09-coap/task04.py
@@ -24,7 +24,7 @@ $ PYTHONPATH="/home/kbee/src/aiocoap" ./task04.py -r [fe80::200:bbff:febb:2%tap0
 
 Result: 2.05 Content
 b'This is RIOT (Version: 2018.04-devel-3264-g99ae4-gazelle-2018.10-branch)
-running on a native board with a native MCU.'
+running on a native64 board with a native MCU.'
 """
 
 import logging

--- a/09-coap/test_spec09.py
+++ b/09-coap/test_spec09.py
@@ -226,8 +226,7 @@ def test_task04(riot_ctrl):
         )
         assert str(response.code) == "2.05 Content"
         assert re.search(
-            r"This is RIOT \(Version: .*\) running on a "
-            r"native board with a native MCU\.",
+            r"This is RIOT \(Version: .*\) running on a \S+ board with a \S+ MCU\.",
             response.payload.decode(),
         )
 


### PR DESCRIPTION
follow-up after https://github.com/RIOT-OS/RIOT/pull/21242 where native was changed to be an alias for native32/64 depending on the host architecture