### PR TITLE
treewide: gnrc/gnrc_* moved to gnrc/

### DIFF
--- a/04-single-hop-6lowpan-icmp/test_spec04.py
+++ b/04-single-hop-6lowpan-icmp/test_spec04.py
@@ -9,7 +9,7 @@ from testutils.asyncio import wait_for_futures
 from testutils.shell import ping6, lladdr, check_pktbuf
 
 
-APP = 'examples/networking/gnrc/gnrc_networking'
+APP = 'examples/networking/gnrc/networking'
 TASK10_APP = 'tests/net/gnrc_udp'
 pytestmark = pytest.mark.rc_only()
 

--- a/05-single-hop-route/test_spec05.py
+++ b/05-single-hop-route/test_spec05.py
@@ -7,7 +7,7 @@ from testutils.native import bridged
 from testutils.shell import ping6, lladdr, check_pktbuf
 
 
-APP = 'examples/networking/gnrc/gnrc_networking'
+APP = 'examples/networking/gnrc/networking'
 pytestmark = pytest.mark.rc_only()
 
 

--- a/08-interop/README.md
+++ b/08-interop/README.md
@@ -84,7 +84,7 @@ ip-addr
 2023-04-14 15:23:36,735 # -- fe80::f6ce:36c6:d8d1:e340
 ```
 
-8. For the RIOT side just use [gnrc_networking](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc/gnrc_networking). Get the link-local IP address with `ifconfig`:
+8. For the RIOT side just use [gnrc_networking](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc/networking). Get the link-local IP address with `ifconfig`:
 
 ```
 2023-04-14 15:11:12,614 # ifconfig
@@ -344,7 +344,7 @@ The credentials for the WiFi network will be passed on the command line.
 Replace `esp8266-esp-12x` with the esp* board of your choice, adjust `PORT` if needed.
 
 ```
-USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/networking/gnrc/gnrc_border_router BOARD=esp<...> UPLINK=wifi WIFI_SSID=<your_ssd> WIFI_PASS=<your_password> PORT=<port> flash term
+USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/networking/gnrc/border_router BOARD=esp<...> UPLINK=wifi WIFI_SSID=<your_ssd> WIFI_PASS=<your_password> PORT=<port> flash term
 ```
 
 ### Result
@@ -413,7 +413,7 @@ Use the `sock_dns` and `gnrc_ipv6_nib_dns` modules to enable name resolution.
 Replace `esp8266-esp-12x` with the esp* board of your choice, adjust `PORT` if needed.
 
 ```
-USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/networking/gnrc/gnrc_networking BOARD=esp<…> PORT=<port> flash term
+USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/networking/gnrc/networking BOARD=esp<…> PORT=<port> flash term
 ```
 
 ### Result

--- a/08-interop/test_spec08.py
+++ b/08-interop/test_spec08.py
@@ -14,7 +14,7 @@ from testutils.native import bridge, get_link_local, get_ping_cmd, interface_exi
 from testutils.shell import lladdr, ping6, GNRCUDP
 
 
-GNRC_APP = 'examples/networking/gnrc/gnrc_networking'
+GNRC_APP = 'examples/networking/gnrc/networking'
 LWIP_APP = 'tests/pkg/lwip'
 pytestmark = pytest.mark.rc_only()
 

--- a/10-icmpv6-error/README.md
+++ b/10-icmpv6-error/README.md
@@ -224,7 +224,7 @@ hop link but not the second hop link via a native node from a Linux host.
 
         $ GNRC_NETIF_NUMOF=2 USEMODULE="socket_zep netdev_tap" \
           CFLAGS=-DGNRC_IPV6_NIB_CONF_SLAAC=1 TERMFLAGS="-z [::]:17755 tap0" \
-            make -C examples/networking/gnrc/gnrc_networking clean all term
+            make -C examples/networking/gnrc/networking clean all term
 
 4. Add `beef::/64` route via TAP interface on RIOT side:
 

--- a/10-icmpv6-error/test_spec10.py
+++ b/10-icmpv6-error/test_spec10.py
@@ -35,7 +35,7 @@ from testutils.native import (
 )
 
 
-APP = 'examples/networking/gnrc/gnrc_networking'
+APP = 'examples/networking/gnrc/networking'
 TAP = 'tap0'
 NETIF_PARSER = IfconfigListParser()
 

--- a/11-lorawan/README.md
+++ b/11-lorawan/README.md
@@ -199,9 +199,9 @@ send/receive LoRaWAN frames.
 
 ### Testing procedure
 
-- Build and flash the `examples/networking/gnrc/gnrc_lorawan`
+- Build and flash the `examples/networking/gnrc/lorawan`
 
-      $ make BOARD=<board> -C examples/networking/gnrc/gnrc_lorawan flash term
+      $ make BOARD=<board> -C examples/networking/gnrc/lorawan flash term
 
 - Configure the device EUI, application EUI, application the `ifconfig` command
 

--- a/11-lorawan/test_spec11.py
+++ b/11-lorawan/test_spec11.py
@@ -10,7 +10,7 @@ from testutils.shell import GNRCLoRaWANSend, ifconfig, lorawan_netif
 from testutils.shell import check_pktbuf
 
 
-GNRC_LORAWAN_APP = "examples/networking/gnrc/gnrc_lorawan"
+GNRC_LORAWAN_APP = "examples/networking/gnrc/lorawan"
 LORAWAN_APP = "examples/networking/misc/lorawan"
 SEMTECH_LORAMAC_APP = "tests/pkg/semtech-loramac"
 pytestmark = pytest.mark.rc_only()

--- a/testutils/shell.py
+++ b/testutils/shell.py
@@ -27,7 +27,7 @@ class GNRCUDPClientSendParser(ShellInteractionParser):
     """
     Shell interaction parser for
 
-    - $RIOTBASE/examples/networking/gnrc/gnrc_networking
+    - $RIOTBASE/examples/networking/gnrc/networking
     - $RIOTBASE/tests/net/gnrc_udp.
 
     As the `udp` shell command is application specific, a central
@@ -78,7 +78,7 @@ class GNRCLoRaWANSend(ShellInteraction):
     """
     Shell interaction for
 
-    - $RIOTBASE/examples/networking/gnrc/gnrc_lorawan
+    - $RIOTBASE/examples/networking/gnrc/lorawan
 
     As the `send` shell command is application specific, a central
     ShellInteraction in `riotctrl_shell` does not make much sense
@@ -99,7 +99,7 @@ class GNRCUDP(ShellInteraction):
     """
     Shell interaction for
 
-    - $RIOTBASE/examples/networking/gnrc/gnrc_networking
+    - $RIOTBASE/examples/networking/gnrc/networking
     - $RIOTBASE/tests/net/gnrc_udp.
 
     As the `udp` shell command is application specific, a central


### PR DESCRIPTION
follow-up to https://github.com/RIOT-OS/RIOT/pull/21826