### PR TITLE
99-compile-and-test-one-board: remove ref to RYOT

### DIFF
--- a/99-compile-and-test-one-board/README.md
+++ b/99-compile-and-test-one-board/README.md
@@ -12,8 +12,7 @@ Run [`02-tests`][02-tests] procedure with your test board connected.
 
 Please make the result files available to the release manager.
 
-Note: For some boards there are weekly runs in the CI in [test-on-iotlab] and [test-on-ryot].
+Note: For some boards there are weekly runs in the CI in [test-on-iotlab].
 
 [02-tests]: ../02-tests
 [test-on-iotlab]: https://github.com/RIOT-OS/RIOT/actions/workflows/test-on-iotlab.yml
-[test-on-ryot]: https://github.com/RIOT-OS/RIOT/actions/workflows/test-on-ryot.yml


### PR DESCRIPTION
That workflow does not exist anymore, so delete it.